### PR TITLE
Change type hints of X | None to Optional[X]

### DIFF
--- a/adambot.py
+++ b/adambot.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import discord
 from discord.ext import commands
 from discord.ext.commands import Bot, when_mentioned_or, when_mentioned
@@ -170,7 +172,7 @@ class AdamBot(Bot):
         if not hasattr(ctx.cog, "on_command_error"):  # don't re-raise if ext handling
             raise error  # re-raise error so cogs can mess around but not block every single error. Does duplicate traceback but error tracebacks are a bloody mess anyway
 
-    def correct_time(self, conv_time: datetime.datetime | None = None,
+    def correct_time(self, conv_time: Optional[datetime.datetime] = None,
                      timezone_: str = "system") -> datetime.datetime:
         if not conv_time:
             conv_time = datetime.datetime.now()

--- a/cogs/guild/guild_features/moderation/filter.py
+++ b/cogs/guild/guild_features/moderation/filter.py
@@ -1,4 +1,6 @@
 from math import ceil
+from typing import Optional
+
 import discord
 from discord.ext import commands
 from libs.misc.decorators import is_staff
@@ -147,7 +149,7 @@ class Filter(commands.Cog):
         if not ctx.invoked_subcommand:
             await ctx.reply(f"Type `{ctx.prefix}help filter` to get info!")
 
-    async def clean_up(self, ctx: commands.Context, text: str, key: str, spoiler: bool = True) -> discord.Message | None:
+    async def clean_up(self, ctx: commands.Context, text: str, key: str, spoiler: bool = True) -> Optional[discord.Message]:
         """
         Strictly only cleans up one list. Cross-checks occur specifically within their own scopes.
         This makes sure space isn't wasted by adding random garbage to the filter that will already be in effect anyway

--- a/cogs/guild/guild_features/role/role.py
+++ b/cogs/guild/guild_features/role/role.py
@@ -658,5 +658,5 @@ class Role(commands.Cog):
         await self.bot.DefaultEmbedResponses.success_embed(self.bot, ctx, "Roles removed successfully!", desc=f"All roles have been removed from {member.mention}" + (f" except for **{(', '.join(fail[:len(fail) - 1]) + f' and {fail[len(fail) - 1]}') if len(fail) > 1 else fail[0]}**, which could not be removed." if fail else ""))
 
 
-async def setup(bot):
+async def setup(bot) -> None:
     await bot.add_cog(Role(bot))

--- a/cogs/guild/guild_features/starboard/starboard.py
+++ b/cogs/guild/guild_features/starboard/starboard.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import discord
 from discord.ext import commands
 import asyncio
@@ -85,7 +87,7 @@ class Starboard:
         self.embed_colour = new_starboard_data["embed_colour"]
         self.allow_self_star = new_starboard_data["allow_self_star"]
 
-    async def try_get_entry(self, message_id: int) -> Entry | None:
+    async def try_get_entry(self, message_id: int) -> Optional[Entry]:
         """
         Returns either a starboard entry or None if it doesn't exist
         """
@@ -175,7 +177,7 @@ class StarboardCog(commands.Cog):
                 results.append(starboard)
         return results
 
-    async def _try_get_starboard(self, channel_id: int) -> Starboard | None:
+    async def _try_get_starboard(self, channel_id: int) -> Optional[Starboard]:
         """
         Return the starboard for the given text channel or None if it doesn't exist
         """

--- a/cogs/guild/member_features/trivia/trivia.py
+++ b/cogs/guild/member_features/trivia/trivia.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import discord
 from discord import Embed, Colour
 from discord.ext import commands
@@ -205,7 +207,7 @@ class Trivia(commands.Cog):
         await self.bot.DefaultEmbedResponses.information_embed(self.bot, ctx, "Available trivias", desc=desc)
 
     @trivia.command(pass_context=True)
-    async def start(self, ctx: commands.Context, trivia: str | None = None) -> None:
+    async def start(self, ctx: commands.Context, trivia: Optional[str] = None) -> None:
         """
         Command that starts a new trivia game in the currently set trivia channel
         """

--- a/libs/misc/utils.py
+++ b/libs/misc/utils.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import discord
 from discord import Embed, Colour, Message, File
 from discord.ext import commands
@@ -232,7 +234,7 @@ async def send_text_file(text: str, channel: discord.TextChannel | discord.Threa
     await channel.send(file=File(buf, filename=f"{filename}.{extension}"))
 
 
-async def get_spaced_member(ctx: commands.Context, bot, *, args: str) -> discord.Member | None:
+async def get_spaced_member(ctx: commands.Context, bot, *, args: str) -> Optional[discord.Member]:
     """
     Moves hell on Earth to get a guild member object from a given string
     Makes use of last_active, a priority temp list that stores member objects of


### PR DESCRIPTION
And added the forgotten return type annotation to setup Role cog

From the [docs](https://docs.python.org/3/library/typing.html#typing.Optional)
> `Optional[X]` is equivalent to `X | None` (or `Union[X, None]`).

Totally up to you tbh lol, `Optional` I guess adds readability?

The return type of `setup()` in all cogs were annotated as `-> None` but one was missing which was why it was added for consistency.