### PR TITLE
Refactored duplicate code

### DIFF
--- a/adambot.py
+++ b/adambot.py
@@ -17,7 +17,7 @@ from tzlocal import get_localzone
 import libs.db.database_handle as database_handle  # not strictly a lib rn but hopefully will be in the future
 import libs.misc.utils as utils
 from libs.misc.decorators import MissingStaffError, MissingDevError, MissingStaffSlashError, MissingDevSlashError
-from libs.misc.utils import DefaultEmbedResponses, ContextTypes, get_context_type
+from libs.misc.utils import DefaultEmbedResponses, ContextTypes, unbox_context
 from scripts.utils import cog_handler
 
 
@@ -84,7 +84,7 @@ class AdamBot(Bot):
     def __init__(self, start_time: float, config_path: str = "config.json", command_prefix: str = "", *args,
                  **kwargs) -> None:
         self.ContextType = ContextTypes
-        self.get_context_type = get_context_type
+        self.unbox_context = unbox_context
         self.internal_config = self.load_internal_config(config_path)
         self.cog_handler = cog_handler.CogHandler(self)
         self.kwargs = kwargs
@@ -129,7 +129,9 @@ class AdamBot(Bot):
         Procedure that closes down AdamBot, using the standard client.close() command, as well as some database handling methods.
         """
 
-        ctx_type = self.get_context_type(ctx)
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
+            return
 
         self.online = False  # This is set to false to prevent DB things going on in the background once bot closed
         user = f"{self.user.mention} " if self.user else ""

--- a/adambot.py
+++ b/adambot.py
@@ -17,7 +17,7 @@ from tzlocal import get_localzone
 import libs.db.database_handle as database_handle  # not strictly a lib rn but hopefully will be in the future
 import libs.misc.utils as utils
 from libs.misc.decorators import MissingStaffError, MissingDevError, MissingStaffSlashError, MissingDevSlashError, unbox_context as unbox_context_decorator
-from libs.misc.utils import DefaultEmbedResponses, ContextTypes, unbox_context
+from libs.misc.utils import DefaultEmbedResponses, ContextTypes
 from scripts.utils import cog_handler
 
 
@@ -84,7 +84,6 @@ class AdamBot(Bot):
     def __init__(self, start_time: float, config_path: str = "config.json", command_prefix: str = "", *args,
                  **kwargs) -> None:
         self.ContextType = ContextTypes
-        self.unbox_context = unbox_context
         self.internal_config = self.load_internal_config(config_path)
         self.cog_handler = cog_handler.CogHandler(self)
         self.kwargs = kwargs

--- a/adambot.py
+++ b/adambot.py
@@ -16,7 +16,7 @@ from tzlocal import get_localzone
 
 import libs.db.database_handle as database_handle  # not strictly a lib rn but hopefully will be in the future
 import libs.misc.utils as utils
-from libs.misc.decorators import MissingStaffError, MissingDevError, MissingStaffSlashError, MissingDevSlashError
+from libs.misc.decorators import MissingStaffError, MissingDevError, MissingStaffSlashError, MissingDevSlashError, unbox_context as unbox_context_decorator
 from libs.misc.utils import DefaultEmbedResponses, ContextTypes, unbox_context
 from scripts.utils import cog_handler
 
@@ -123,15 +123,12 @@ class AdamBot(Bot):
 
         print(f"BOT INITIALISED {self._init_time - start_time} seconds")
 
+    @unbox_context_decorator
     async def shutdown(self,
-                       ctx: commands.Context | discord.Interaction = None) -> None:  # ctx = None because this is also called upon CTRL+C in command line
+                       ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction = None) -> None:  # ctx = None because this is also called upon CTRL+C in command line
         """
         Procedure that closes down AdamBot, using the standard client.close() command, as well as some database handling methods.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         self.online = False  # This is set to false to prevent DB things going on in the background once bot closed
         user = f"{self.user.mention} " if self.user else ""

--- a/cogs/bot/bot_handlers.py
+++ b/cogs/bot/bot_handlers.py
@@ -66,9 +66,8 @@ class BotHandlers:
         Constructs and sends the botinfo embed.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
 
         app_info = await self.bot.application_info()
@@ -94,11 +93,6 @@ class BotHandlers:
         if hasattr(app_info, "icon"):
             embed.set_thumbnail(url=app_info.icon.url)
 
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
-
         embed.set_footer(text=f"Requested by: {author.display_name} ({author})\n" + (self.bot.correct_time()).strftime(
             self.bot.ts_format), icon_url=get_user_avatar_url(author, mode=1)[0])
 
@@ -114,9 +108,8 @@ class BotHandlers:
         Allows a user to check if the bot is currently hosted locally or remotely.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
 
         string = f"Adam-bot is {'**locally**' if self.bot.LOCAL_HOST else '**remotely**'} hosted right now."
@@ -133,9 +126,8 @@ class BotHandlers:
         Allows a user to view the bot's current latency
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
 
         string = f"Pong! ({round(self.bot.latency * 1000)} ms)"
@@ -152,9 +144,8 @@ class BotHandlers:
         Allows a user to view how long the bot has been running for
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
 
         seconds = round(time.time() - self.bot.start_time)  # Rounds to the nearest integer

--- a/cogs/bot/bot_handlers.py
+++ b/cogs/bot/bot_handlers.py
@@ -10,7 +10,7 @@ from discord import Embed
 from discord.ext import commands
 
 from adambot import AdamBot
-from libs.misc.decorators import unbox_context
+from libs.misc.decorators import unbox_context_args
 from libs.misc.utils import get_user_avatar_url, ContextTypes
 
 
@@ -60,13 +60,15 @@ class BotHandlers:
         self.commit_url = f"{self.remote_url}/commit/{self.commit_hash}" if type(
             self.commit_page) is not str and self.commit_page.status_code == 200 else "" if self.commit_page else ""
 
-    @unbox_context
-    async def botinfo(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None:
+    @unbox_context_args
+    async def botinfo(self, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the botinfo commands.
 
         Constructs and sends the botinfo embed.
         """
+
+        (ctx_type, author) = self.command_args
 
         app_info = await self.bot.application_info()
         embed = Embed(title=f"Bot info for ({self.bot.user})",
@@ -99,14 +101,15 @@ class BotHandlers:
         else:
             await ctx.response.send_message(embed=embed)
 
-    @unbox_context
-    async def host(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None:
+    @unbox_context_args
+    async def host(self, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the host commands.
 
         Allows a user to check if the bot is currently hosted locally or remotely.
         """
 
+        (ctx_type, author) = self.command_args
         string = f"Adam-bot is {'**locally**' if self.bot.LOCAL_HOST else '**remotely**'} hosted right now."
 
         if ctx_type == self.ContextTypes.Context:
@@ -114,14 +117,15 @@ class BotHandlers:
         else:
             await ctx.response.send_message(string)
 
-    @unbox_context
-    async def ping(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None:
+    @unbox_context_args
+    async def ping(self, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the ping commands.
 
         Allows a user to view the bot's current latency
         """
 
+        (ctx_type, author) = self.command_args
         string = f"Pong! ({round(self.bot.latency * 1000)} ms)"
 
         if ctx_type == self.ContextTypes.Context:
@@ -129,14 +133,15 @@ class BotHandlers:
         else:
             await ctx.response.send_message(string)
 
-    @unbox_context
-    async def uptime(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None:
+    @unbox_context_args
+    async def uptime(self, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the uptime commands.
 
         Allows a user to view how long the bot has been running for
         """
         
+        (ctx_type, author) = self.command_args
         seconds = round(time.time() - self.bot.start_time)  # Rounds to the nearest integer
         time_string = self.bot.time_str(seconds)
 

--- a/cogs/bot/bot_handlers.py
+++ b/cogs/bot/bot_handlers.py
@@ -10,7 +10,8 @@ from discord import Embed
 from discord.ext import commands
 
 from adambot import AdamBot
-from libs.misc.utils import get_user_avatar_url
+from libs.misc.decorators import unbox_context
+from libs.misc.utils import get_user_avatar_url, ContextTypes
 
 
 class BotHandlers:
@@ -59,16 +60,13 @@ class BotHandlers:
         self.commit_url = f"{self.remote_url}/commit/{self.commit_hash}" if type(
             self.commit_page) is not str and self.commit_page.status_code == 200 else "" if self.commit_page else ""
 
-    async def botinfo(self, ctx: commands.Context | discord.Interaction) -> None:
+    @unbox_context
+    async def botinfo(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the botinfo commands.
 
         Constructs and sends the botinfo embed.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         app_info = await self.bot.application_info()
         embed = Embed(title=f"Bot info for ({self.bot.user})",
@@ -101,16 +99,13 @@ class BotHandlers:
         else:
             await ctx.response.send_message(embed=embed)
 
-    async def host(self, ctx: commands.Context | discord.Interaction) -> None:
+    @unbox_context
+    async def host(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the host commands.
 
         Allows a user to check if the bot is currently hosted locally or remotely.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         string = f"Adam-bot is {'**locally**' if self.bot.LOCAL_HOST else '**remotely**'} hosted right now."
 
@@ -119,16 +114,13 @@ class BotHandlers:
         else:
             await ctx.response.send_message(string)
 
-    async def ping(self, ctx: commands.Context | discord.Interaction) -> None:
+    @unbox_context
+    async def ping(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the ping commands.
 
         Allows a user to view the bot's current latency
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         string = f"Pong! ({round(self.bot.latency * 1000)} ms)"
 
@@ -137,17 +129,14 @@ class BotHandlers:
         else:
             await ctx.response.send_message(string)
 
-    async def uptime(self, ctx: commands.Context | discord.Interaction) -> None:
+    @unbox_context
+    async def uptime(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the uptime commands.
 
         Allows a user to view how long the bot has been running for
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
-
+        
         seconds = round(time.time() - self.bot.start_time)  # Rounds to the nearest integer
         time_string = self.bot.time_str(seconds)
 

--- a/cogs/bot/bot_handlers.py
+++ b/cogs/bot/bot_handlers.py
@@ -10,19 +10,16 @@ from discord import Embed
 from discord.ext import commands
 
 from adambot import AdamBot
-from libs.misc.decorators import unbox_context_args
-from libs.misc.utils import get_user_avatar_url, ContextTypes
+from libs.misc.handler import CommandHandler
+from libs.misc.utils import get_user_avatar_url
 
 
-class BotHandlers:
+class BotHandlers(CommandHandler):
     def __init__(self, bot: AdamBot) -> None:
         """
         Initialises the class and also tries to determine the commit and branch the bot is running on where applicable
         """
-
-        self.bot = bot
-
-        self.ContextTypes = self.bot.ContextTypes
+        super().__init__(self, bot)
 
         self.remote_url = os.environ.get("AB_REMOTE_URL")
         self.given_commit_hash = os.environ.get("AB_COMMIT_HASH")
@@ -60,7 +57,6 @@ class BotHandlers:
         self.commit_url = f"{self.remote_url}/commit/{self.commit_hash}" if type(
             self.commit_page) is not str and self.commit_page.status_code == 200 else "" if self.commit_page else ""
 
-    @unbox_context_args
     async def botinfo(self, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the botinfo commands.
@@ -101,7 +97,6 @@ class BotHandlers:
         else:
             await ctx.response.send_message(embed=embed)
 
-    @unbox_context_args
     async def host(self, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the host commands.
@@ -117,7 +112,6 @@ class BotHandlers:
         else:
             await ctx.response.send_message(string)
 
-    @unbox_context_args
     async def ping(self, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the ping commands.
@@ -133,7 +127,6 @@ class BotHandlers:
         else:
             await ctx.response.send_message(string)
 
-    @unbox_context_args
     async def uptime(self, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the uptime commands.

--- a/cogs/dev/eval_handlers.py
+++ b/cogs/dev/eval_handlers.py
@@ -5,7 +5,7 @@ import discord
 from discord.ext import commands
 
 from adambot import AdamBot
-from libs.misc.decorators import unbox_context
+from libs.misc.decorators import unbox_context_args
 from libs.misc.utils import ContextTypes
 
 
@@ -21,14 +21,16 @@ class EvalHandlers:
             text = text[2000:]
         return chunks
 
-    @unbox_context
-    async def evaluate(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, command: str = "") -> None:
+    @unbox_context_args
+    async def evaluate(self, ctx: commands.Context | discord.Interaction, command: str = "") -> None:
         """
         Handler for the evaluate commands.
 
         Allows evaluating strings of code (intended for testing).
         If something doesn't output correctly try wrapping in str()
         """
+
+        (ctx_type, author) = self.command_args
 
         try:
             output = eval(command)
@@ -57,12 +59,13 @@ class EvalHandlers:
             e.replace(os.getcwd(), ".")
             await ctx.channel.send(e)
 
-    @unbox_context
-    async def execute(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, command: str = "") -> None:
+    @unbox_context_args
+    async def execute(self, ctx: commands.Context | discord.Interaction, command: str = "") -> None:
         """
         Handler for the execute commands.
         """
 
+        (ctx_type, author) = self.command_args
         async with self.bot.pool.acquire() as connection:
             try:
                 await connection.execute(command)
@@ -74,12 +77,13 @@ class EvalHandlers:
                 else:
                     await ctx.response.send_message(msg)
 
-    @unbox_context
-    async def fetch(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, command: str = "") -> None:
+    @unbox_context_args
+    async def fetch(self, ctx: commands.Context | discord.Interaction, command: str = "") -> None:
         """
         Handler for the fetch commands.
         """
 
+        (ctx_type, author) = self.command_args
         async with self.bot.pool.acquire() as connection:
             try:
                 records = await connection.fetch(command)

--- a/cogs/dev/eval_handlers.py
+++ b/cogs/dev/eval_handlers.py
@@ -27,9 +27,8 @@ class EvalHandlers:
         If something doesn't output correctly try wrapping in str()
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-
-        if ctx_type == self.bot.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
 
         try:
@@ -64,9 +63,8 @@ class EvalHandlers:
         Handler for the execute commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-
-        if ctx_type == self.bot.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
 
         async with self.bot.pool.acquire() as connection:
@@ -85,9 +83,8 @@ class EvalHandlers:
         Handler for the fetch commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-
-        if ctx_type == self.bot.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
 
         async with self.bot.pool.acquire() as connection:

--- a/cogs/dev/eval_handlers.py
+++ b/cogs/dev/eval_handlers.py
@@ -5,13 +5,11 @@ import discord
 from discord.ext import commands
 
 from adambot import AdamBot
-from libs.misc.decorators import unbox_context_args
-from libs.misc.utils import ContextTypes
+from libs.misc.handler import CommandHandler
 
-
-class EvalHandlers:
+class EvalHandlers(CommandHandler):
     def __init__(self, bot: AdamBot) -> None:
-        self.bot = bot
+        super().__init__(self, bot)
 
     @staticmethod
     def split_2000(text: str) -> list[str]:
@@ -21,7 +19,6 @@ class EvalHandlers:
             text = text[2000:]
         return chunks
 
-    @unbox_context_args
     async def evaluate(self, ctx: commands.Context | discord.Interaction, command: str = "") -> None:
         """
         Handler for the evaluate commands.
@@ -59,7 +56,6 @@ class EvalHandlers:
             e.replace(os.getcwd(), ".")
             await ctx.channel.send(e)
 
-    @unbox_context_args
     async def execute(self, ctx: commands.Context | discord.Interaction, command: str = "") -> None:
         """
         Handler for the execute commands.
@@ -77,7 +73,6 @@ class EvalHandlers:
                 else:
                     await ctx.response.send_message(msg)
 
-    @unbox_context_args
     async def fetch(self, ctx: commands.Context | discord.Interaction, command: str = "") -> None:
         """
         Handler for the fetch commands.

--- a/cogs/dev/eval_handlers.py
+++ b/cogs/dev/eval_handlers.py
@@ -5,6 +5,8 @@ import discord
 from discord.ext import commands
 
 from adambot import AdamBot
+from libs.misc.decorators import unbox_context
+from libs.misc.utils import ContextTypes
 
 
 class EvalHandlers:
@@ -19,17 +21,14 @@ class EvalHandlers:
             text = text[2000:]
         return chunks
 
-    async def evaluate(self, ctx: commands.Context | discord.Interaction, command: str = "") -> None:
+    @unbox_context
+    async def evaluate(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, command: str = "") -> None:
         """
         Handler for the evaluate commands.
 
         Allows evaluating strings of code (intended for testing).
         If something doesn't output correctly try wrapping in str()
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         try:
             output = eval(command)
@@ -58,14 +57,11 @@ class EvalHandlers:
             e.replace(os.getcwd(), ".")
             await ctx.channel.send(e)
 
-    async def execute(self, ctx: commands.Context | discord.Interaction, command: str = "") -> None:
+    @unbox_context
+    async def execute(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, command: str = "") -> None:
         """
         Handler for the execute commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         async with self.bot.pool.acquire() as connection:
             try:
@@ -78,14 +74,11 @@ class EvalHandlers:
                 else:
                     await ctx.response.send_message(msg)
 
-    async def fetch(self, ctx: commands.Context | discord.Interaction, command: str = "") -> None:
+    @unbox_context
+    async def fetch(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, command: str = "") -> None:
         """
         Handler for the fetch commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         async with self.bot.pool.acquire() as connection:
             try:

--- a/cogs/guild/guild_features/demographics/demographics_handlers.py
+++ b/cogs/guild/guild_features/demographics/demographics_handlers.py
@@ -6,7 +6,7 @@ from matplotlib import pyplot as plt
 from matplotlib.dates import DateFormatter
 
 from adambot import AdamBot
-from libs.misc.decorators import unbox_context
+from libs.misc.decorators import unbox_context_args
 from libs.misc.utils import ContextTypes
 
 
@@ -16,14 +16,15 @@ class DemographicsHandlers:
         self.cog = cog
         self.ContextTypes = self.bot.ContextTypes
 
-    @unbox_context
-    async def viewroles(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None:
+    @unbox_context_args
+    async def viewroles(self, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the viewroles commands.
 
         Responds with a list of role names for roles that are tracked within the context guild.
         """
 
+        (ctx_type, author) = self.command_args
         role_ids = await self.cog._get_roles(ctx.guild)
         roles = [ctx.guild.get_role(x).name for x in role_ids]
         message = "Currently tracked roles are: " + ", ".join(roles)
@@ -33,13 +34,15 @@ class DemographicsHandlers:
         else:
             await ctx.response.send_message(message)
 
-    @unbox_context
-    async def addrole(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, role: discord.Role, sample_rate: int) -> None:
+    @unbox_context_args
+    async def addrole(self, ctx: commands.Context | discord.Interaction, role: discord.Role, sample_rate: int) -> None:
         """
         Handler for the addrole commands.
 
         Adds a role to be sampled for the context guild.
         """
+
+        (ctx_type, author) = self.command_args
 
         def check(m: discord.Message) -> bool:
             return m.author == author and m.channel == ctx.channel
@@ -92,13 +95,15 @@ class DemographicsHandlers:
             else:
                 await ctx.response.send_message(message)
 
-    @unbox_context
-    async def removerole(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, role: discord.Role) -> None:
+    @unbox_context_args
+    async def removerole(self, ctx: commands.Context | discord.Interaction, role: discord.Role) -> None:
         """
         Handler for the removerole commands.
 
         Removes a role from being sampled for the context guild.
         """
+
+        (ctx_type, author) = self.command_args
 
         def check(m: discord.Message) -> bool:
             return m.author == author and m.channel == ctx.channel
@@ -144,14 +149,15 @@ class DemographicsHandlers:
             else:
                 await ctx.response.send_message(message)
 
-    @unbox_context
-    async def takesample(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, role: discord.Role) -> None:
+    @unbox_context_args
+    async def takesample(self, ctx: commands.Context | discord.Interaction, role: discord.Role) -> None:
         """
         Handler for the takesample commands.
 
         Takes a sample immediately for a given role within a context guild.
         """
 
+        (ctx_type, author) = self.command_args
         guild_tracked_roles = await self.cog._get_roles(ctx.guild)
         if not role:
             # Take a sample of all roles
@@ -204,14 +210,15 @@ class DemographicsHandlers:
         else:
             await ctx.response.send_message(message)
 
-    @unbox_context
-    async def removeallsamples(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None:
+    @unbox_context_args
+    async def removeallsamples(self, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the removeallsamples commands.
 
         Removes all samples for a context guild.
         """
 
+        (ctx_type, author) = self.command_args
         async with self.bot.pool.acquire() as connection:
             await connection.execute(
                 "DELETE FROM demographic_samples WHERE role_reference IN (SELECT id FROM demographic_roles WHERE guild_id = $1);",
@@ -224,14 +231,15 @@ class DemographicsHandlers:
         else:
             await ctx.response.send_message(message)
 
-    @unbox_context
-    async def show(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None:
+    @unbox_context_args
+    async def show(self, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the show commands.
 
         Shows the numbers of members with each tracked role within a context guild.
         """
 
+        (ctx_type, author) = self.command_args
         tracked_roles = [ctx.guild.get_role(r) for r in await self.cog._get_roles(ctx.guild) if
                          ctx.guild.get_role(r) is not None]
         message = f"There are a total of **{ctx.guild.member_count}** users in **{ctx.guild.name}**."

--- a/cogs/guild/guild_features/demographics/demographics_handlers.py
+++ b/cogs/guild/guild_features/demographics/demographics_handlers.py
@@ -6,6 +6,8 @@ from matplotlib import pyplot as plt
 from matplotlib.dates import DateFormatter
 
 from adambot import AdamBot
+from libs.misc.decorators import unbox_context
+from libs.misc.utils import ContextTypes
 
 
 class DemographicsHandlers:
@@ -14,16 +16,13 @@ class DemographicsHandlers:
         self.cog = cog
         self.ContextTypes = self.bot.ContextTypes
 
-    async def viewroles(self, ctx: commands.Context | discord.Interaction) -> None:
+    @unbox_context
+    async def viewroles(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the viewroles commands.
 
         Responds with a list of role names for roles that are tracked within the context guild.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         role_ids = await self.cog._get_roles(ctx.guild)
         roles = [ctx.guild.get_role(x).name for x in role_ids]
@@ -34,16 +33,13 @@ class DemographicsHandlers:
         else:
             await ctx.response.send_message(message)
 
-    async def addrole(self, ctx: commands.Context | discord.Interaction, role: discord.Role, sample_rate: int) -> None:
+    @unbox_context
+    async def addrole(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, role: discord.Role, sample_rate: int) -> None:
         """
         Handler for the addrole commands.
 
         Adds a role to be sampled for the context guild.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         def check(m: discord.Message) -> bool:
             return m.author == author and m.channel == ctx.channel
@@ -96,16 +92,13 @@ class DemographicsHandlers:
             else:
                 await ctx.response.send_message(message)
 
-    async def removerole(self, ctx: commands.Context | discord.Interaction, role: discord.Role) -> None:
+    @unbox_context
+    async def removerole(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, role: discord.Role) -> None:
         """
         Handler for the removerole commands.
 
         Removes a role from being sampled for the context guild.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         def check(m: discord.Message) -> bool:
             return m.author == author and m.channel == ctx.channel
@@ -151,16 +144,13 @@ class DemographicsHandlers:
             else:
                 await ctx.response.send_message(message)
 
-    async def takesample(self, ctx: commands.Context | discord.Interaction, role: discord.Role) -> None:
+    @unbox_context
+    async def takesample(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, role: discord.Role) -> None:
         """
         Handler for the takesample commands.
 
         Takes a sample immediately for a given role within a context guild.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         guild_tracked_roles = await self.cog._get_roles(ctx.guild)
         if not role:
@@ -214,16 +204,13 @@ class DemographicsHandlers:
         else:
             await ctx.response.send_message(message)
 
-    async def removeallsamples(self, ctx: commands.Context | discord.Interaction) -> None:
+    @unbox_context
+    async def removeallsamples(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the removeallsamples commands.
 
         Removes all samples for a context guild.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         async with self.bot.pool.acquire() as connection:
             await connection.execute(
@@ -237,16 +224,13 @@ class DemographicsHandlers:
         else:
             await ctx.response.send_message(message)
 
-    async def show(self, ctx: commands.Context | discord.Interaction) -> None:
+    @unbox_context
+    async def show(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the show commands.
 
         Shows the numbers of members with each tracked role within a context guild.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         tracked_roles = [ctx.guild.get_role(r) for r in await self.cog._get_roles(ctx.guild) if
                          ctx.guild.get_role(r) is not None]

--- a/cogs/guild/guild_features/demographics/demographics_handlers.py
+++ b/cogs/guild/guild_features/demographics/demographics_handlers.py
@@ -21,9 +21,8 @@ class DemographicsHandlers:
         Responds with a list of role names for roles that are tracked within the context guild.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
 
         role_ids = await self.cog._get_roles(ctx.guild)
@@ -42,14 +41,9 @@ class DemographicsHandlers:
         Adds a role to be sampled for the context guild.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         def check(m: discord.Message) -> bool:
             return m.author == author and m.channel == ctx.channel
@@ -109,15 +103,9 @@ class DemographicsHandlers:
         Removes a role from being sampled for the context guild.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         def check(m: discord.Message) -> bool:
             return m.author == author and m.channel == ctx.channel
@@ -170,15 +158,9 @@ class DemographicsHandlers:
         Takes a sample immediately for a given role within a context guild.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         guild_tracked_roles = await self.cog._get_roles(ctx.guild)
         if not role:
@@ -239,8 +221,8 @@ class DemographicsHandlers:
         Removes all samples for a context guild.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
 
         async with self.bot.pool.acquire() as connection:
@@ -262,8 +244,8 @@ class DemographicsHandlers:
         Shows the numbers of members with each tracked role within a context guild.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
 
         tracked_roles = [ctx.guild.get_role(r) for r in await self.cog._get_roles(ctx.guild) if

--- a/cogs/guild/guild_features/demographics/demographics_handlers.py
+++ b/cogs/guild/guild_features/demographics/demographics_handlers.py
@@ -6,17 +6,15 @@ from matplotlib import pyplot as plt
 from matplotlib.dates import DateFormatter
 
 from adambot import AdamBot
-from libs.misc.decorators import unbox_context_args
-from libs.misc.utils import ContextTypes
+from libs.misc.handler import CommandHandler
 
 
-class DemographicsHandlers:
+class DemographicsHandlers(CommandHandler):
     def __init__(self, bot: AdamBot, cog: commands.Cog) -> None:  # note that this should really be of type Demographics but circular dependency needs to be resolved first
-        self.bot = bot
+        super().__init__(self, bot)
         self.cog = cog
         self.ContextTypes = self.bot.ContextTypes
 
-    @unbox_context_args
     async def viewroles(self, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the viewroles commands.
@@ -34,7 +32,6 @@ class DemographicsHandlers:
         else:
             await ctx.response.send_message(message)
 
-    @unbox_context_args
     async def addrole(self, ctx: commands.Context | discord.Interaction, role: discord.Role, sample_rate: int) -> None:
         """
         Handler for the addrole commands.
@@ -95,7 +92,6 @@ class DemographicsHandlers:
             else:
                 await ctx.response.send_message(message)
 
-    @unbox_context_args
     async def removerole(self, ctx: commands.Context | discord.Interaction, role: discord.Role) -> None:
         """
         Handler for the removerole commands.
@@ -149,7 +145,6 @@ class DemographicsHandlers:
             else:
                 await ctx.response.send_message(message)
 
-    @unbox_context_args
     async def takesample(self, ctx: commands.Context | discord.Interaction, role: discord.Role) -> None:
         """
         Handler for the takesample commands.
@@ -210,7 +205,6 @@ class DemographicsHandlers:
         else:
             await ctx.response.send_message(message)
 
-    @unbox_context_args
     async def removeallsamples(self, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the removeallsamples commands.
@@ -231,7 +225,6 @@ class DemographicsHandlers:
         else:
             await ctx.response.send_message(message)
 
-    @unbox_context_args
     async def show(self, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the show commands.

--- a/cogs/guild/guild_features/moderation/moderation_handlers.py
+++ b/cogs/guild/guild_features/moderation/moderation_handlers.py
@@ -7,11 +7,11 @@ from discord.ext import commands
 from discord.utils import get
 
 from adambot import AdamBot
-from libs.misc.decorators import unbox_context_args
+from libs.misc.handler import CommandHandler
 from libs.misc.utils import ContextTypes, get_user_avatar_url
 
 
-class ModerationHandlers:
+class ModerationHandlers(CommandHandler):
     def __init__(self, bot: AdamBot) -> None:
         self.bot = bot
         self.ContextTypes = self.bot.ContextTypes
@@ -56,7 +56,6 @@ class ModerationHandlers:
 
         await self.bot.shutdown(ctx)
 
-    @unbox_context_args
     async def purge(self, ctx: commands.Context | discord.Interaction, limit: str | int = 5,
                     member: discord.Member = None) -> None:
         """
@@ -105,7 +104,6 @@ class ModerationHandlers:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Invalid number of messages provided!",
                                                              desc=f"Please use an integer for the amount of messages to delete, not `{limit}` :ok_hand:")
 
-    @unbox_context_args
     async def kick(self, ctx: commands.Context | discord.Interaction, member: str | discord.Member,
                    reason: str = "No reason provided", args: str = "") -> None:
         """
@@ -146,7 +144,6 @@ class ModerationHandlers:
         embed.set_footer(text=self.bot.correct_time().strftime(self.bot.ts_format))
         await channel.send(embed=embed)
 
-    @unbox_context_args
     async def ban(self, ctx: commands.Context | discord.Interaction, members: str | discord.Member,
                   reason: str = "No reason provided", timeperiod: str = None) -> None:
         """
@@ -309,7 +306,6 @@ class ModerationHandlers:
         except Exception:
             pass  # go away!
 
-    @unbox_context_args
     async def unban(self, ctx: commands.Context | discord.Interaction, member: str, args: str = None,
                     reason: str = "No reason provided") -> None:
         """
@@ -366,7 +362,6 @@ class ModerationHandlers:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Could not add a slowmode here!",
                                                              desc="You must specify a whole number of seconds!")
 
-    @unbox_context_args
     async def say(self, ctx: commands.Context | discord.Interaction,
                   channel: discord.TextChannel | discord.Thread | app_commands.AppCommandThread, text: str):
         """
@@ -427,7 +422,6 @@ class ModerationHandlers:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Could not delete invite!",
                                                              desc=f"Invite revoking failed: {e}")
 
-    @unbox_context_args
     async def mute(self, ctx: commands.Context | discord.Interaction, member: discord.Member,
                    reason: str = "No reason provided!", timeperiod: int | str = "", args: str = "") -> None:
         """

--- a/cogs/guild/guild_features/moderation/moderation_handlers.py
+++ b/cogs/guild/guild_features/moderation/moderation_handlers.py
@@ -7,7 +7,7 @@ from discord.ext import commands
 from discord.utils import get
 
 from adambot import AdamBot
-from libs.misc.decorators import unbox_context
+from libs.misc.decorators import unbox_context_args
 from libs.misc.utils import ContextTypes, get_user_avatar_url
 
 
@@ -56,13 +56,14 @@ class ModerationHandlers:
 
         await self.bot.shutdown(ctx)
 
-    @unbox_context
-    async def purge(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, limit: str | int = 5,
+    @unbox_context_args
+    async def purge(self, ctx: commands.Context | discord.Interaction, limit: str | int = 5,
                     member: discord.Member = None) -> None:
         """
         Handler for the purge commands.
         """
 
+        (ctx_type, author) = self.command_args
         channel = ctx.channel
 
         if (type(limit) is str and limit.isdigit()) or type(limit) is int:
@@ -104,13 +105,14 @@ class ModerationHandlers:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Invalid number of messages provided!",
                                                              desc=f"Please use an integer for the amount of messages to delete, not `{limit}` :ok_hand:")
 
-    @unbox_context
-    async def kick(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, member: str | discord.Member,
+    @unbox_context_args
+    async def kick(self, ctx: commands.Context | discord.Interaction, member: str | discord.Member,
                    reason: str = "No reason provided", args: str = "") -> None:
         """
         Handler for the kick commands.
         """
 
+        (ctx_type, author) = self.command_args
         if ctx.guild.me.top_role < member.top_role:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Could not kick member!",
                                                              desc=f"Can't kick {member.mention}, they have a higher role than the bot!")
@@ -144,13 +146,14 @@ class ModerationHandlers:
         embed.set_footer(text=self.bot.correct_time().strftime(self.bot.ts_format))
         await channel.send(embed=embed)
 
-    @unbox_context
-    async def ban(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, members: str | discord.Member,
+    @unbox_context_args
+    async def ban(self, ctx: commands.Context | discord.Interaction, members: str | discord.Member,
                   reason: str = "No reason provided", timeperiod: str = None) -> None:
         """
         Handler for the ban commands.
         """
 
+        (ctx_type, author) = self.command_args
         if not ctx.guild.me.guild_permissions.ban_members:
             await self.bot.DefaultEmbedResponses(self.bot, ctx, "Could not proceed with the ban!",
                                                  desc="I don't have permissions to ban members in this server!")
@@ -306,13 +309,14 @@ class ModerationHandlers:
         except Exception:
             pass  # go away!
 
-    @unbox_context
-    async def unban(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, member: str, args: str = None,
+    @unbox_context_args
+    async def unban(self, ctx: commands.Context | discord.Interaction, member: str, args: str = None,
                     reason: str = "No reason provided") -> None:
         """
         Handler for the unban commands.
         """
 
+        (ctx_type, author) = self.command_args
         if args:
             parsed_args = self.bot.flag_handler.separate_args(args, fetch=["reason"], blank_as_flag="reason")
             reason = parsed_args["reason"] if parsed_args["reason"] and reason == "No reason provided" else reason
@@ -362,13 +366,14 @@ class ModerationHandlers:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Could not add a slowmode here!",
                                                              desc="You must specify a whole number of seconds!")
 
-    @unbox_context
-    async def say(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction,
+    @unbox_context_args
+    async def say(self, ctx: commands.Context | discord.Interaction,
                   channel: discord.TextChannel | discord.Thread | app_commands.AppCommandThread, text: str):
         """
         Handler for the say commands.
         """
 
+        (ctx_type, author) = self.command_args
         await channel.send(text[5:] if text.startswith("/tts") else text,
                            tts=text.startswith("/tts ") and channel.permissions_for(author).send_tts_messages)
 
@@ -422,13 +427,14 @@ class ModerationHandlers:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Could not delete invite!",
                                                              desc=f"Invite revoking failed: {e}")
 
-    @unbox_context
-    async def mute(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, member: discord.Member,
+    @unbox_context_args
+    async def mute(self, ctx: commands.Context | discord.Interaction, member: discord.Member,
                    reason: str = "No reason provided!", timeperiod: int | str = "", args: str = "") -> None:
         """
         Handler for the mute commands.
         """
 
+        (ctx_type, author) = self.command_args
         role = get(member.guild.roles, id=await self.bot.get_config_key(member, "muted_role"))
         if not role:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Could not mute member!",

--- a/cogs/guild/guild_features/moderation/moderation_handlers.py
+++ b/cogs/guild/guild_features/moderation/moderation_handlers.py
@@ -61,15 +61,9 @@ class ModerationHandlers:
         Handler for the purge commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type is self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
-
         channel = ctx.channel
 
         if (type(limit) is str and limit.isdigit()) or type(limit) is int:
@@ -117,14 +111,9 @@ class ModerationHandlers:
         Handler for the kick commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type is self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         if ctx.guild.me.top_role < member.top_role:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Could not kick member!",
@@ -165,14 +154,9 @@ class ModerationHandlers:
         Handler for the ban commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type is self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         if not ctx.guild.me.guild_permissions.ban_members:
             await self.bot.DefaultEmbedResponses(self.bot, ctx, "Could not proceed with the ban!",
@@ -335,14 +319,9 @@ class ModerationHandlers:
         Handler for the unban commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type is self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         if args:
             parsed_args = self.bot.flag_handler.separate_args(args, fetch=["reason"], blank_as_flag="reason")
@@ -371,14 +350,9 @@ class ModerationHandlers:
         Handler for the slowmode commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type is self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         if not ctx.channel.permissions_for(author).manage_channels:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Could not add a slowmode here!",
@@ -408,14 +382,9 @@ class ModerationHandlers:
         Handler for the say commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type is self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         await channel.send(text[5:] if text.startswith("/tts") else text,
                            tts=text.startswith("/tts ") and channel.permissions_for(author).send_tts_messages)
@@ -476,14 +445,9 @@ class ModerationHandlers:
         Handler for the mute commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type is self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         role = get(member.guild.roles, id=await self.bot.get_config_key(member, "muted_role"))
         if not role:

--- a/cogs/guild/guild_features/moderation/moderation_handlers.py
+++ b/cogs/guild/guild_features/moderation/moderation_handlers.py
@@ -7,7 +7,8 @@ from discord.ext import commands
 from discord.utils import get
 
 from adambot import AdamBot
-from libs.misc.utils import get_user_avatar_url
+from libs.misc.decorators import unbox_context
+from libs.misc.utils import ContextTypes, get_user_avatar_url
 
 
 class ModerationHandlers:
@@ -55,15 +56,13 @@ class ModerationHandlers:
 
         await self.bot.shutdown(ctx)
 
-    async def purge(self, ctx: commands.Context | discord.Interaction, limit: str | int = 5,
+    @unbox_context
+    async def purge(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, limit: str | int = 5,
                     member: discord.Member = None) -> None:
         """
         Handler for the purge commands.
         """
 
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
         channel = ctx.channel
 
         if (type(limit) is str and limit.isdigit()) or type(limit) is int:
@@ -105,15 +104,12 @@ class ModerationHandlers:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Invalid number of messages provided!",
                                                              desc=f"Please use an integer for the amount of messages to delete, not `{limit}` :ok_hand:")
 
-    async def kick(self, ctx: commands.Context | discord.Interaction, member: str | discord.Member,
+    @unbox_context
+    async def kick(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, member: str | discord.Member,
                    reason: str = "No reason provided", args: str = "") -> None:
         """
         Handler for the kick commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         if ctx.guild.me.top_role < member.top_role:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Could not kick member!",
@@ -148,15 +144,12 @@ class ModerationHandlers:
         embed.set_footer(text=self.bot.correct_time().strftime(self.bot.ts_format))
         await channel.send(embed=embed)
 
-    async def ban(self, ctx: commands.Context | discord.Interaction, members: str | discord.Member,
+    @unbox_context
+    async def ban(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, members: str | discord.Member,
                   reason: str = "No reason provided", timeperiod: str = None) -> None:
         """
         Handler for the ban commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         if not ctx.guild.me.guild_permissions.ban_members:
             await self.bot.DefaultEmbedResponses(self.bot, ctx, "Could not proceed with the ban!",
@@ -313,15 +306,12 @@ class ModerationHandlers:
         except Exception:
             pass  # go away!
 
-    async def unban(self, ctx: commands.Context | discord.Interaction, member: str, args: str = None,
+    @unbox_context
+    async def unban(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, member: str, args: str = None,
                     reason: str = "No reason provided") -> None:
         """
         Handler for the unban commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         if args:
             parsed_args = self.bot.flag_handler.separate_args(args, fetch=["reason"], blank_as_flag="reason")
@@ -345,14 +335,10 @@ class ModerationHandlers:
         await self.bot.DefaultEmbedResponses.success_embed(self.bot, ctx, "Unbanned member successfully!",
                                                            desc=f"{member.mention} has been unbanned!")
 
-    async def slowmode(self, ctx: commands.Context | discord.Interaction, time: str | int) -> None:
+    async def slowmode(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, time: str | int) -> None:
         """
         Handler for the slowmode commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         if not ctx.channel.permissions_for(author).manage_channels:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Could not add a slowmode here!",
@@ -376,15 +362,12 @@ class ModerationHandlers:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Could not add a slowmode here!",
                                                              desc="You must specify a whole number of seconds!")
 
-    async def say(self, ctx: commands.Context | discord.Interaction,
+    @unbox_context
+    async def say(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction,
                   channel: discord.TextChannel | discord.Thread | app_commands.AppCommandThread, text: str):
         """
         Handler for the say commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         await channel.send(text[5:] if text.startswith("/tts") else text,
                            tts=text.startswith("/tts ") and channel.permissions_for(author).send_tts_messages)
@@ -439,15 +422,12 @@ class ModerationHandlers:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Could not delete invite!",
                                                              desc=f"Invite revoking failed: {e}")
 
-    async def mute(self, ctx: commands.Context | discord.Interaction, member: discord.Member,
+    @unbox_context
+    async def mute(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, member: discord.Member,
                    reason: str = "No reason provided!", timeperiod: int | str = "", args: str = "") -> None:
         """
         Handler for the mute commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         role = get(member.guild.roles, id=await self.bot.get_config_key(member, "muted_role"))
         if not role:

--- a/cogs/guild/guild_features/moderation/waitingroom_handlers.py
+++ b/cogs/guild/guild_features/moderation/waitingroom_handlers.py
@@ -4,7 +4,7 @@ import datetime
 import discord
 from discord import Embed, Colour
 from discord.ext import commands
-from libs.misc.decorators import unbox_context
+from libs.misc.decorators import unbox_context_args
 
 from libs.misc.utils import ContextTypes, get_user_avatar_url
 
@@ -15,13 +15,14 @@ class WaitingroomHandlers:
         self.ContextTypes = self.bot.ContextTypes
         self.cog = cog
 
-    @unbox_context
-    async def testwelcome(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction,
+    @unbox_context_args
+    async def testwelcome(self, ctx: commands.Context | discord.Interaction,
                           to_ping: discord.Member | discord.User = None) -> None:
         """
         Handler for the testwelcome commands.
         """
 
+        (ctx_type, author) = self.command_args
         msg = await self.bot.get_config_key(ctx, "welcome_msg")
         if msg is None:
             message = "A welcome message has not been set."
@@ -40,12 +41,13 @@ class WaitingroomHandlers:
         else:
             await ctx.response.send_message(message)
 
-    @unbox_context
-    async def lurker(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, phrase: str) -> None:
+    @unbox_context_args
+    async def lurker(self, ctx: commands.Context | discord.Interaction, phrase: str) -> None:
         """
         Handler for the lurker commands.
         """
 
+        (ctx_type, author) = self.command_args
         if ctx_type == self.ContextTypes.Interaction:
             await ctx.response.send_message(":ok_hand:")
 
@@ -117,12 +119,13 @@ class WaitingroomHandlers:
                 await ctx.channel.send(f"""{author.mention} To save time, you can provide a default message to be displayed on the lurker command, i.e. you don't need to type out the phrase each time.
         You can set this by doing `{ctx.prefix}config set lurker_phrase {phrase}`""")
 
-    @unbox_context
-    async def lurker_kick(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, days: int | str = 7) -> None:
+    @unbox_context_args
+    async def lurker_kick(self, ctx: commands.Context | discord.Interaction, days: int | str = 7) -> None:
         """
         Handler for the lurker_kick commands.
         """
 
+        (ctx_type, author) = self.command_args
         def check(m: discord.Message) -> bool:
             return m.channel == ctx.channel and m.author == author
 

--- a/cogs/guild/guild_features/moderation/waitingroom_handlers.py
+++ b/cogs/guild/guild_features/moderation/waitingroom_handlers.py
@@ -4,8 +4,9 @@ import datetime
 import discord
 from discord import Embed, Colour
 from discord.ext import commands
+from libs.misc.decorators import unbox_context
 
-from libs.misc.utils import get_user_avatar_url
+from libs.misc.utils import ContextTypes, get_user_avatar_url
 
 
 class WaitingroomHandlers:
@@ -14,15 +15,12 @@ class WaitingroomHandlers:
         self.ContextTypes = self.bot.ContextTypes
         self.cog = cog
 
-    async def testwelcome(self, ctx: commands.Context | discord.Interaction,
+    @unbox_context
+    async def testwelcome(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction,
                           to_ping: discord.Member | discord.User = None) -> None:
         """
         Handler for the testwelcome commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         msg = await self.bot.get_config_key(ctx, "welcome_msg")
         if msg is None:
@@ -42,14 +40,11 @@ class WaitingroomHandlers:
         else:
             await ctx.response.send_message(message)
 
-    async def lurker(self, ctx: commands.Context | discord.Interaction, phrase: str) -> None:
+    @unbox_context
+    async def lurker(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, phrase: str) -> None:
         """
         Handler for the lurker commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         if ctx_type == self.ContextTypes.Interaction:
             await ctx.response.send_message(":ok_hand:")
@@ -122,14 +117,11 @@ class WaitingroomHandlers:
                 await ctx.channel.send(f"""{author.mention} To save time, you can provide a default message to be displayed on the lurker command, i.e. you don't need to type out the phrase each time.
         You can set this by doing `{ctx.prefix}config set lurker_phrase {phrase}`""")
 
-    async def lurker_kick(self, ctx: commands.Context | discord.Interaction, days: int | str = 7) -> None:
+    @unbox_context
+    async def lurker_kick(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, days: int | str = 7) -> None:
         """
         Handler for the lurker_kick commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         def check(m: discord.Message) -> bool:
             return m.channel == ctx.channel and m.author == author

--- a/cogs/guild/guild_features/moderation/waitingroom_handlers.py
+++ b/cogs/guild/guild_features/moderation/waitingroom_handlers.py
@@ -4,18 +4,16 @@ import datetime
 import discord
 from discord import Embed, Colour
 from discord.ext import commands
-from libs.misc.decorators import unbox_context_args
 
-from libs.misc.utils import ContextTypes, get_user_avatar_url
+from libs.misc.handler import CommandHandler
+from libs.misc.utils import get_user_avatar_url
 
 
-class WaitingroomHandlers:
+class WaitingroomHandlers(CommandHandler):
     def __init__(self, bot, cog):
-        self.bot = bot
-        self.ContextTypes = self.bot.ContextTypes
+        super().__init__(self, bot)
         self.cog = cog
 
-    @unbox_context_args
     async def testwelcome(self, ctx: commands.Context | discord.Interaction,
                           to_ping: discord.Member | discord.User = None) -> None:
         """
@@ -41,7 +39,6 @@ class WaitingroomHandlers:
         else:
             await ctx.response.send_message(message)
 
-    @unbox_context_args
     async def lurker(self, ctx: commands.Context | discord.Interaction, phrase: str) -> None:
         """
         Handler for the lurker commands.
@@ -119,7 +116,6 @@ class WaitingroomHandlers:
                 await ctx.channel.send(f"""{author.mention} To save time, you can provide a default message to be displayed on the lurker command, i.e. you don't need to type out the phrase each time.
         You can set this by doing `{ctx.prefix}config set lurker_phrase {phrase}`""")
 
-    @unbox_context_args
     async def lurker_kick(self, ctx: commands.Context | discord.Interaction, days: int | str = 7) -> None:
         """
         Handler for the lurker_kick commands.

--- a/cogs/guild/guild_features/moderation/waitingroom_handlers.py
+++ b/cogs/guild/guild_features/moderation/waitingroom_handlers.py
@@ -20,9 +20,8 @@ class WaitingroomHandlers:
         Handler for the testwelcome commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
 
         msg = await self.bot.get_config_key(ctx, "welcome_msg")
@@ -36,7 +35,7 @@ class WaitingroomHandlers:
             return
 
         message = await self.cog.get_parsed_welcome_message(msg,
-                                                            to_ping or ctx.author)  # to_ping or author means the author unless to_ping is provided.
+                                                            to_ping or author)  # to_ping or author means the author unless to_ping is provided.
 
         if ctx_type == self.ContextTypes.Context:
             await ctx.send(message)
@@ -48,16 +47,12 @@ class WaitingroomHandlers:
         Handler for the lurker commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
 
         if ctx_type == self.ContextTypes.Interaction:
             await ctx.response.send_message(":ok_hand:")
-            author = ctx.user
-        else:
-            author = ctx.author
 
         phrase = phrase.split(" ")
         # Get default phrase if there is one, but the one given in the command overrides the config one
@@ -132,15 +127,9 @@ class WaitingroomHandlers:
         Handler for the lurker_kick commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Interaction:
-            author = ctx.user
-        else:
-            author = ctx.author
 
         def check(m: discord.Message) -> bool:
             return m.channel == ctx.channel and m.author == author

--- a/cogs/guild/guild_features/moderation/warnings_handlers.py
+++ b/cogs/guild/guild_features/moderation/warnings_handlers.py
@@ -17,14 +17,9 @@ class WarningHandlers:
         Handles getting the warns for a specific member
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         async with self.bot.pool.acquire() as connection:
             warns = await connection.fetch("SELECT * FROM warn WHERE member_id = ($1) AND guild_id = $2 ORDER BY id;",
@@ -57,14 +52,9 @@ class WarningHandlers:
         Handler for the warn commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         parsed_args = self.bot.flag_handler.separate_args(reason, fetch=["reason"], blank_as_flag="reason")
         reason = parsed_args["reason"]
@@ -94,14 +84,9 @@ class WarningHandlers:
         Handler for the warns commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         if await self.bot.is_staff(ctx):
             if not member:
@@ -146,8 +131,8 @@ class WarningHandlers:
         Handler for the warnremove commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx) # TODO: Is this potentially a redundant check?
+        if not author:
             return
 
         warnings = warnings.split(" ") if type(warnings) is str else warnings

--- a/cogs/guild/guild_features/moderation/warnings_handlers.py
+++ b/cogs/guild/guild_features/moderation/warnings_handlers.py
@@ -1,18 +1,16 @@
 import discord
 from discord import Colour
 from discord.ext import commands
-from libs.misc.decorators import unbox_context_args
 
-from libs.misc.utils import ContextTypes, get_user_avatar_url, get_guild_icon_url
+from libs.misc.handler import CommandHandler
+from libs.misc.utils import get_user_avatar_url, get_guild_icon_url
 
 
-class WarningHandlers:
+class WarningHandlers(CommandHandler):
     def __init__(self, bot, cog):
-        self.bot = bot
+        super().__init__(self, bot)
         self.cog = cog
-        self.ContextTypes = self.bot.ContextTypes
 
-    @unbox_context_args
     async def _warnlist_member(self, ctx: commands.Context | discord.Interaction, member: discord.Member,
                                page_num: int = 1) -> None:
         """
@@ -46,7 +44,6 @@ class WarningHandlers:
             await self.bot.DefaultEmbedResponses.information_embed(self.bot, ctx, "Couldn't find any warnings!",
                                                                    desc=f"No warnings recorded for {member.mention}!")
 
-    @unbox_context_args
     async def warn(self, ctx: commands.Context | discord.Interaction, member: discord.Member, reason: str = "") -> None:
         """
         Handler for the warn commands.
@@ -75,7 +72,6 @@ class WarningHandlers:
         except Exception as e:
             print(e)
 
-    @unbox_context_args
     async def warns(self, ctx: commands.Context | discord.Interaction,
                     member: discord.Member | discord.User = None) -> None:
         """
@@ -121,7 +117,6 @@ class WarningHandlers:
                 await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Couldn't find anything!",
                                                                  desc="You don't have permission to view other people's warns.")
 
-    @unbox_context_args
     async def warnremove(self, ctx: commands.Context | discord.Interaction, warnings: str):
         """
         Handler for the warnremove commands.

--- a/cogs/guild/guild_features/moderation/warnings_handlers.py
+++ b/cogs/guild/guild_features/moderation/warnings_handlers.py
@@ -1,8 +1,9 @@
 import discord
 from discord import Colour
 from discord.ext import commands
+from libs.misc.decorators import unbox_context
 
-from libs.misc.utils import get_user_avatar_url, get_guild_icon_url
+from libs.misc.utils import ContextTypes, get_user_avatar_url, get_guild_icon_url
 
 
 class WarningHandlers:
@@ -11,15 +12,12 @@ class WarningHandlers:
         self.cog = cog
         self.ContextTypes = self.bot.ContextTypes
 
-    async def _warnlist_member(self, ctx: commands.Context | discord.Interaction, member: discord.Member,
+    @unbox_context
+    async def _warnlist_member(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, member: discord.Member,
                                page_num: int = 1) -> None:
         """
         Handles getting the warns for a specific member
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         async with self.bot.pool.acquire() as connection:
             warns = await connection.fetch("SELECT * FROM warn WHERE member_id = ($1) AND guild_id = $2 ORDER BY id;",
@@ -47,14 +45,11 @@ class WarningHandlers:
             await self.bot.DefaultEmbedResponses.information_embed(self.bot, ctx, "Couldn't find any warnings!",
                                                                    desc=f"No warnings recorded for {member.mention}!")
 
-    async def warn(self, ctx: commands.Context | discord.Interaction, member: discord.Member, reason: str = "") -> None:
+    @unbox_context
+    async def warn(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, member: discord.Member, reason: str = "") -> None:
         """
         Handler for the warn commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         parsed_args = self.bot.flag_handler.separate_args(reason, fetch=["reason"], blank_as_flag="reason")
         reason = parsed_args["reason"]
@@ -78,15 +73,12 @@ class WarningHandlers:
         except Exception as e:
             print(e)
 
-    async def warns(self, ctx: commands.Context | discord.Interaction,
+    @unbox_context
+    async def warns(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction,
                     member: discord.Member | discord.User = None) -> None:
         """
         Handler for the warns commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         if await self.bot.is_staff(ctx):
             if not member:
@@ -126,14 +118,11 @@ class WarningHandlers:
                 await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Couldn't find anything!",
                                                                  desc="You don't have permission to view other people's warns.")
 
-    async def warnremove(self, ctx: commands.Context | discord.Interaction, warnings: str):
+    @unbox_context
+    async def warnremove(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, warnings: str):
         """
         Handler for the warnremove commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx) # TODO: Is this potentially a redundant check?
-        if not author:
-            return
 
         warnings = warnings.split(" ") if type(warnings) is str else warnings
         async with self.bot.pool.acquire() as connection:

--- a/cogs/guild/guild_features/moderation/warnings_handlers.py
+++ b/cogs/guild/guild_features/moderation/warnings_handlers.py
@@ -1,7 +1,7 @@
 import discord
 from discord import Colour
 from discord.ext import commands
-from libs.misc.decorators import unbox_context
+from libs.misc.decorators import unbox_context_args
 
 from libs.misc.utils import ContextTypes, get_user_avatar_url, get_guild_icon_url
 
@@ -12,13 +12,14 @@ class WarningHandlers:
         self.cog = cog
         self.ContextTypes = self.bot.ContextTypes
 
-    @unbox_context
-    async def _warnlist_member(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, member: discord.Member,
+    @unbox_context_args
+    async def _warnlist_member(self, ctx: commands.Context | discord.Interaction, member: discord.Member,
                                page_num: int = 1) -> None:
         """
         Handles getting the warns for a specific member
         """
 
+        (ctx_type, author) = self.command_args
         async with self.bot.pool.acquire() as connection:
             warns = await connection.fetch("SELECT * FROM warn WHERE member_id = ($1) AND guild_id = $2 ORDER BY id;",
                                            member.id, ctx.guild.id)
@@ -45,12 +46,13 @@ class WarningHandlers:
             await self.bot.DefaultEmbedResponses.information_embed(self.bot, ctx, "Couldn't find any warnings!",
                                                                    desc=f"No warnings recorded for {member.mention}!")
 
-    @unbox_context
-    async def warn(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, member: discord.Member, reason: str = "") -> None:
+    @unbox_context_args
+    async def warn(self, ctx: commands.Context | discord.Interaction, member: discord.Member, reason: str = "") -> None:
         """
         Handler for the warn commands.
         """
 
+        (ctx_type, author) = self.command_args
         parsed_args = self.bot.flag_handler.separate_args(reason, fetch=["reason"], blank_as_flag="reason")
         reason = parsed_args["reason"]
         if len(reason) > 255:
@@ -73,13 +75,14 @@ class WarningHandlers:
         except Exception as e:
             print(e)
 
-    @unbox_context
-    async def warns(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction,
+    @unbox_context_args
+    async def warns(self, ctx: commands.Context | discord.Interaction,
                     member: discord.Member | discord.User = None) -> None:
         """
         Handler for the warns commands.
         """
 
+        (ctx_type, author) = self.command_args
         if await self.bot.is_staff(ctx):
             if not member:
                 # Show all warns
@@ -118,8 +121,8 @@ class WarningHandlers:
                 await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Couldn't find anything!",
                                                                  desc="You don't have permission to view other people's warns.")
 
-    @unbox_context
-    async def warnremove(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, warnings: str):
+    @unbox_context_args
+    async def warnremove(self, ctx: commands.Context | discord.Interaction, warnings: str):
         """
         Handler for the warnremove commands.
         """

--- a/cogs/guild/guild_features/role/reactionroles_handlers.py
+++ b/cogs/guild/guild_features/role/reactionroles_handlers.py
@@ -36,8 +36,8 @@ class ReactionrolesHandlers:
     async def add(self, ctx: commands.Context | discord.Interaction, emoji: discord.Emoji | str, role: discord.Role,
                   inverse: bool | str = None, message_id: int | str = None) -> None:
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type is self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
 
         if not ctx.guild.me.guild_permissions.manage_roles:
@@ -95,8 +95,8 @@ class ReactionrolesHandlers:
 
     async def remove(self, ctx: commands.Context | discord.Interaction, emoji: discord.Emoji | str,
                      message_id: int | str = None) -> None:
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type is self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
 
         if ctx_type == self.ContextTypes.Context and not message_id:
@@ -133,8 +133,8 @@ class ReactionrolesHandlers:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Could not find the specified message!")
 
     async def delete(self, ctx: commands.Context | discord.Interaction, message_id=None) -> None:
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type is self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
 
         if ctx_type == self.ContextTypes.Context and not message_id:
@@ -156,8 +156,8 @@ class ReactionrolesHandlers:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Could not find the specified message!")
 
     async def showreactionroles(self, ctx: commands.Context | discord.Interaction) -> None:
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type is self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
 
         async with self.bot.pool.acquire() as connection:
@@ -166,8 +166,8 @@ class ReactionrolesHandlers:
         embed = discord.Embed(title=f":information_source: {ctx.guild.name} reaction roles",
                               color=self.bot.INFORMATION_BLUE)
         embed.set_footer(
-            text=f"Requested by: {ctx.author.display_name} ({ctx.author})\n" + self.bot.correct_time().strftime(
-                self.bot.ts_format), icon_url=get_user_avatar_url(ctx.author, mode=1)[0])
+            text=f"Requested by: {author.display_name} ({author})\n" + self.bot.correct_time().strftime(
+                self.bot.ts_format), icon_url=get_user_avatar_url(author, mode=1)[0])
 
         message_reactions = {}  # ID -> str (to put in embed)
         message_channels = {}  # ID -> discord.TextChannel

--- a/cogs/guild/guild_features/role/reactionroles_handlers.py
+++ b/cogs/guild/guild_features/role/reactionroles_handlers.py
@@ -5,7 +5,7 @@ import discord
 from discord.ext import commands
 
 from adambot import AdamBot
-from libs.misc.decorators import unbox_context
+from libs.misc.decorators import unbox_context_args
 from libs.misc.utils import ContextTypes, get_user_avatar_url
 
 
@@ -34,11 +34,11 @@ class ReactionrolesHandlers:
             to_return.append([role, data[i][1]])
         return to_return
 
-    @unbox_context
-    async def add(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, emoji: discord.Emoji | str, role: discord.Role,
+    @unbox_context_args
+    async def add(self, ctx: commands.Context | discord.Interaction, emoji: discord.Emoji | str, role: discord.Role,
                   inverse: bool | str = None, message_id: int | str = None) -> None:
 
-
+        (ctx_type, author) = self.command_args
         if not ctx.guild.me.guild_permissions.manage_roles:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "I do not have manage-role permissions!",
                                                              desc="I need these permissions to create the reaction role.")
@@ -92,10 +92,11 @@ class ReactionrolesHandlers:
         else:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Could not find the specified message!")
 
-    @unbox_context
-    async def remove(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, emoji: discord.Emoji | str,
+    @unbox_context_args
+    async def remove(self, ctx: commands.Context | discord.Interaction, emoji: discord.Emoji | str,
                      message_id: int | str = None) -> None:
         
+        (ctx_type, author) = self.command_args
         if ctx_type == self.ContextTypes.Context and not message_id:
             message_id = ctx.message.reference.message_id
 
@@ -129,9 +130,10 @@ class ReactionrolesHandlers:
         else:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Could not find the specified message!")
 
-    @unbox_context
-    async def delete(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, message_id=None) -> None:
+    @unbox_context_args
+    async def delete(self, ctx: commands.Context | discord.Interaction, message_id=None) -> None:
         
+        (ctx_type, author) = self.command_args
         if ctx_type == self.ContextTypes.Context and not message_id:
             message_id = ctx.message.reference.message_id
 
@@ -150,9 +152,10 @@ class ReactionrolesHandlers:
         else:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Could not find the specified message!")
 
-    @unbox_context
-    async def showreactionroles(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None:
+    @unbox_context_args
+    async def showreactionroles(self, ctx: commands.Context | discord.Interaction) -> None:
         
+        (ctx_type, author) = self.command_args
         async with self.bot.pool.acquire() as connection:
             data = await connection.fetch("SELECT * FROM reaction_roles WHERE guild_id = $1;", ctx.guild.id)
 

--- a/cogs/guild/guild_features/role/reactionroles_handlers.py
+++ b/cogs/guild/guild_features/role/reactionroles_handlers.py
@@ -5,14 +5,13 @@ import discord
 from discord.ext import commands
 
 from adambot import AdamBot
-from libs.misc.decorators import unbox_context_args
-from libs.misc.utils import ContextTypes, get_user_avatar_url
+from libs.misc.handler import CommandHandler
+from libs.misc.utils import get_user_avatar_url
 
 
-class ReactionrolesHandlers:
+class ReactionrolesHandlers(CommandHandler):
     def __init__(self, bot: AdamBot) -> None:
-        self.bot = bot
-        self.ContextTypes = self.bot.ContextTypes
+        super().__init__(self, bot)
 
     async def _get_roles(self, payload) -> Optional[list]:
         """
@@ -34,7 +33,6 @@ class ReactionrolesHandlers:
             to_return.append([role, data[i][1]])
         return to_return
 
-    @unbox_context_args
     async def add(self, ctx: commands.Context | discord.Interaction, emoji: discord.Emoji | str, role: discord.Role,
                   inverse: bool | str = None, message_id: int | str = None) -> None:
 
@@ -92,7 +90,6 @@ class ReactionrolesHandlers:
         else:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Could not find the specified message!")
 
-    @unbox_context_args
     async def remove(self, ctx: commands.Context | discord.Interaction, emoji: discord.Emoji | str,
                      message_id: int | str = None) -> None:
         
@@ -130,7 +127,6 @@ class ReactionrolesHandlers:
         else:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Could not find the specified message!")
 
-    @unbox_context_args
     async def delete(self, ctx: commands.Context | discord.Interaction, message_id=None) -> None:
         
         (ctx_type, author) = self.command_args
@@ -152,7 +148,6 @@ class ReactionrolesHandlers:
         else:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Could not find the specified message!")
 
-    @unbox_context_args
     async def showreactionroles(self, ctx: commands.Context | discord.Interaction) -> None:
         
         (ctx_type, author) = self.command_args

--- a/cogs/guild/guild_features/role/reactionroles_handlers.py
+++ b/cogs/guild/guild_features/role/reactionroles_handlers.py
@@ -5,7 +5,8 @@ import discord
 from discord.ext import commands
 
 from adambot import AdamBot
-from libs.misc.utils import get_user_avatar_url
+from libs.misc.decorators import unbox_context
+from libs.misc.utils import ContextTypes, get_user_avatar_url
 
 
 class ReactionrolesHandlers:
@@ -33,12 +34,10 @@ class ReactionrolesHandlers:
             to_return.append([role, data[i][1]])
         return to_return
 
-    async def add(self, ctx: commands.Context | discord.Interaction, emoji: discord.Emoji | str, role: discord.Role,
+    @unbox_context
+    async def add(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, emoji: discord.Emoji | str, role: discord.Role,
                   inverse: bool | str = None, message_id: int | str = None) -> None:
 
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         if not ctx.guild.me.guild_permissions.manage_roles:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "I do not have manage-role permissions!",
@@ -93,12 +92,10 @@ class ReactionrolesHandlers:
         else:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Could not find the specified message!")
 
-    async def remove(self, ctx: commands.Context | discord.Interaction, emoji: discord.Emoji | str,
+    @unbox_context
+    async def remove(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, emoji: discord.Emoji | str,
                      message_id: int | str = None) -> None:
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
-
+        
         if ctx_type == self.ContextTypes.Context and not message_id:
             message_id = ctx.message.reference.message_id
 
@@ -132,11 +129,9 @@ class ReactionrolesHandlers:
         else:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Could not find the specified message!")
 
-    async def delete(self, ctx: commands.Context | discord.Interaction, message_id=None) -> None:
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
-
+    @unbox_context
+    async def delete(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, message_id=None) -> None:
+        
         if ctx_type == self.ContextTypes.Context and not message_id:
             message_id = ctx.message.reference.message_id
 
@@ -155,11 +150,9 @@ class ReactionrolesHandlers:
         else:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Could not find the specified message!")
 
-    async def showreactionroles(self, ctx: commands.Context | discord.Interaction) -> None:
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
-
+    @unbox_context
+    async def showreactionroles(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None:
+        
         async with self.bot.pool.acquire() as connection:
             data = await connection.fetch("SELECT * FROM reaction_roles WHERE guild_id = $1;", ctx.guild.id)
 

--- a/cogs/guild/guild_features/role/role_handlers.py
+++ b/cogs/guild/guild_features/role/role_handlers.py
@@ -43,14 +43,9 @@ class RoleHandlers:
         if action not in ["add", "remove"]:
             return
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         verb = "added" if action == "add" else "removed"
         reason = f"Requested by {author}"
@@ -181,14 +176,9 @@ class RoleHandlers:
         Handler for the info commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         if type(role) is not discord.Role:
             role = await self.find_closest_role(ctx, role, verbosity=Verbosity.ALL)
@@ -221,14 +211,9 @@ class RoleHandlers:
         Handler for the list commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         embed = self.bot.EmbedPages(
             self.bot.PageTypes.ROLE_LIST,
@@ -253,8 +238,8 @@ class RoleHandlers:
         Handler for the members commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
 
         if type(role) is not discord.Role:
@@ -313,8 +298,8 @@ class RoleHandlers:
         Handler for the swap commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
 
         if type(swap_from) is not discord.Role:
@@ -378,8 +363,8 @@ class RoleHandlers:
         Handler for the removeall commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
 
         if type(role) is not discord.Role:
@@ -427,8 +412,8 @@ class RoleHandlers:
         Handler for the addall commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
 
         if type(ref_role) is not discord.Role:

--- a/cogs/guild/guild_features/role/role_handlers.py
+++ b/cogs/guild/guild_features/role/role_handlers.py
@@ -5,7 +5,8 @@ from discord import Embed, errors
 from discord.ext import commands
 
 from adambot import AdamBot
-from libs.misc.utils import get_user_avatar_url, get_guild_icon_url
+from libs.misc.decorators import unbox_context
+from libs.misc.utils import ContextTypes, get_user_avatar_url, get_guild_icon_url
 
 
 class Verbosity:  # Using enum.Enum means that ">" and "<" operations cannot be performed, e.g. Verbosity.ALL > Verbosity.MINIMAL
@@ -27,7 +28,9 @@ class RoleHandlers:
         self.bot = bot
         self.ContextTypes = self.bot.ContextTypes
 
-    async def checked_role_change(self, ctx: commands.Context | discord.Interaction, role: discord.Role,
+    @unbox_context
+    async def checked_role_change(self, ctx_type: ContextTypes, author: discord.User | discord.Member,
+                                  ctx: commands.Context | discord.Interaction, role: discord.Role,
                                   member: discord.Member, action: str, tracker: discord.Message = None,
                                   part_of_more: bool = False, single_output: bool = True) -> Optional[int | float]:
         """
@@ -41,10 +44,6 @@ class RoleHandlers:
         """
 
         if action not in ["add", "remove"]:
-            return
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
             return
 
         verb = "added" if action == "add" else "removed"
@@ -171,14 +170,11 @@ class RoleHandlers:
 
         return possible
 
-    async def info(self, ctx: commands.Context | discord.Interaction, role: discord.Role | str) -> None:
+    @unbox_context
+    async def info(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, role: discord.Role | str) -> None:
         """
         Handler for the info commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         if type(role) is not discord.Role:
             role = await self.find_closest_role(ctx, role, verbosity=Verbosity.ALL)
@@ -206,14 +202,11 @@ class RoleHandlers:
         else:
             await ctx.response.send_message(embed=embed)
 
-    async def list_server_roles(self, ctx: commands.Context | discord.Interaction) -> None:
+    @unbox_context
+    async def list_server_roles(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the list commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         embed = self.bot.EmbedPages(
             self.bot.PageTypes.ROLE_LIST,
@@ -233,14 +226,11 @@ class RoleHandlers:
         await embed.set_page(1)
         await embed.send()
 
-    async def members(self, ctx: commands.Context | discord.Interaction, role: discord.Role | str) -> None:
+    @unbox_context
+    async def members(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, role: discord.Role | str) -> None:
         """
         Handler for the members commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         if type(role) is not discord.Role:
             possible = await self.find_closest_role(ctx, role, verbosity=Verbosity.ALL)
@@ -292,15 +282,12 @@ class RoleHandlers:
 
         await self.checked_role_change(ctx, role, member, "remove")
 
-    async def swap(self, ctx: commands.Context | discord.Interaction, swap_from: discord.Role | str,
+    @unbox_context
+    async def swap(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, swap_from: discord.Role | str,
                    swap_to: discord.Role | str) -> None:
         """
         Handler for the swap commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         if type(swap_from) is not discord.Role:
             swap_from = await self.find_closest_role(ctx, swap_from, verbosity=Verbosity.ALL)
@@ -358,14 +345,11 @@ class RoleHandlers:
                                                                 + (
                                                                     "" if already_got_dest_role == 0 else f" ({already_got_dest_role} already had {swap_to.mention})"))
 
-    async def removeall(self, ctx: commands.Context | discord.Interaction, role: discord.Role | str) -> None:
+    @unbox_context
+    async def removeall(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, role: discord.Role | str) -> None:
         """
         Handler for the removeall commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         if type(role) is not discord.Role:
             role = await self.find_closest_role(ctx, role, verbosity=Verbosity.ALL)
@@ -406,15 +390,12 @@ class RoleHandlers:
 
         await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Nothing to do!", desc="Nobody has this role!")
 
-    async def addall(self, ctx: commands.Context | discord.Interaction, ref_role: discord.Role | str,
+    @unbox_context
+    async def addall(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, ref_role: discord.Role | str,
                      add_role: discord.Role | str) -> None:
         """
         Handler for the addall commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         if type(ref_role) is not discord.Role:
             ref_role = await self.find_closest_role(ctx, ref_role, verbosity=Verbosity.ALL)

--- a/cogs/guild/guild_features/role/role_handlers.py
+++ b/cogs/guild/guild_features/role/role_handlers.py
@@ -5,7 +5,7 @@ from discord import Embed, errors
 from discord.ext import commands
 
 from adambot import AdamBot
-from libs.misc.decorators import unbox_context
+from libs.misc.decorators import unbox_context_args
 from libs.misc.utils import ContextTypes, get_user_avatar_url, get_guild_icon_url
 
 
@@ -28,9 +28,8 @@ class RoleHandlers:
         self.bot = bot
         self.ContextTypes = self.bot.ContextTypes
 
-    @unbox_context
-    async def checked_role_change(self, ctx_type: ContextTypes, author: discord.User | discord.Member,
-                                  ctx: commands.Context | discord.Interaction, role: discord.Role,
+    @unbox_context_args
+    async def checked_role_change(self, ctx: commands.Context | discord.Interaction, role: discord.Role,
                                   member: discord.Member, action: str, tracker: discord.Message = None,
                                   part_of_more: bool = False, single_output: bool = True) -> Optional[int | float]:
         """
@@ -43,6 +42,7 @@ class RoleHandlers:
             None: Oi gimme valid action
         """
 
+        (ctx_type, author) = self.command_args
         if action not in ["add", "remove"]:
             return
 
@@ -170,12 +170,13 @@ class RoleHandlers:
 
         return possible
 
-    @unbox_context
-    async def info(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, role: discord.Role | str) -> None:
+    @unbox_context_args
+    async def info(self, ctx: commands.Context | discord.Interaction, role: discord.Role | str) -> None:
         """
         Handler for the info commands.
         """
 
+        (ctx_type, author) = self.command_args
         if type(role) is not discord.Role:
             role = await self.find_closest_role(ctx, role, verbosity=Verbosity.ALL)
             if len(role) > 1:
@@ -202,12 +203,13 @@ class RoleHandlers:
         else:
             await ctx.response.send_message(embed=embed)
 
-    @unbox_context
-    async def list_server_roles(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None:
+    @unbox_context_args
+    async def list_server_roles(self, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the list commands.
         """
 
+        (ctx_type, author) = self.command_args
         embed = self.bot.EmbedPages(
             self.bot.PageTypes.ROLE_LIST,
             ctx.guild.roles[1:][::-1],
@@ -226,12 +228,13 @@ class RoleHandlers:
         await embed.set_page(1)
         await embed.send()
 
-    @unbox_context
-    async def members(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, role: discord.Role | str) -> None:
+    @unbox_context_args
+    async def members(self, ctx: commands.Context | discord.Interaction, role: discord.Role | str) -> None:
         """
         Handler for the members commands.
         """
 
+        (ctx_type, author) = self.command_args
         if type(role) is not discord.Role:
             possible = await self.find_closest_role(ctx, role, verbosity=Verbosity.ALL)
 
@@ -282,13 +285,14 @@ class RoleHandlers:
 
         await self.checked_role_change(ctx, role, member, "remove")
 
-    @unbox_context
-    async def swap(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, swap_from: discord.Role | str,
+    @unbox_context_args
+    async def swap(self, ctx: commands.Context | discord.Interaction, swap_from: discord.Role | str,
                    swap_to: discord.Role | str) -> None:
         """
         Handler for the swap commands.
         """
 
+        (ctx_type, author) = self.command_args
         if type(swap_from) is not discord.Role:
             swap_from = await self.find_closest_role(ctx, swap_from, verbosity=Verbosity.ALL)
             if len(swap_from) > 1:
@@ -345,12 +349,13 @@ class RoleHandlers:
                                                                 + (
                                                                     "" if already_got_dest_role == 0 else f" ({already_got_dest_role} already had {swap_to.mention})"))
 
-    @unbox_context
-    async def removeall(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, role: discord.Role | str) -> None:
+    @unbox_context_args
+    async def removeall(self, ctx: commands.Context | discord.Interaction, role: discord.Role | str) -> None:
         """
         Handler for the removeall commands.
         """
 
+        (ctx_type, author) = self.command_args
         if type(role) is not discord.Role:
             role = await self.find_closest_role(ctx, role, verbosity=Verbosity.ALL)
             if len(role) > 1:
@@ -390,13 +395,14 @@ class RoleHandlers:
 
         await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Nothing to do!", desc="Nobody has this role!")
 
-    @unbox_context
-    async def addall(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, ref_role: discord.Role | str,
+    @unbox_context_args
+    async def addall(self, ctx: commands.Context | discord.Interaction, ref_role: discord.Role | str,
                      add_role: discord.Role | str) -> None:
         """
         Handler for the addall commands.
         """
 
+        (ctx_type, author) = self.command_args
         if type(ref_role) is not discord.Role:
             ref_role = await self.find_closest_role(ctx, ref_role, verbosity=Verbosity.ALL)
             if len(ref_role) > 1:

--- a/cogs/guild/guild_features/role/role_handlers.py
+++ b/cogs/guild/guild_features/role/role_handlers.py
@@ -5,8 +5,8 @@ from discord import Embed, errors
 from discord.ext import commands
 
 from adambot import AdamBot
-from libs.misc.decorators import unbox_context_args
-from libs.misc.utils import ContextTypes, get_user_avatar_url, get_guild_icon_url
+from libs.misc.handler import CommandHandler
+from libs.misc.utils import get_user_avatar_url, get_guild_icon_url
 
 
 class Verbosity:  # Using enum.Enum means that ">" and "<" operations cannot be performed, e.g. Verbosity.ALL > Verbosity.MINIMAL
@@ -23,12 +23,10 @@ class CheckedRoleChangeResult:  # Used for the results of the `Role.checked_role
     CRITICAL_ERROR = 2
 
 
-class RoleHandlers:
+class RoleHandlers(CommandHandler):
     def __init__(self, bot: AdamBot) -> None:
-        self.bot = bot
-        self.ContextTypes = self.bot.ContextTypes
+        super().__init__(self, bot)
 
-    @unbox_context_args
     async def checked_role_change(self, ctx: commands.Context | discord.Interaction, role: discord.Role,
                                   member: discord.Member, action: str, tracker: discord.Message = None,
                                   part_of_more: bool = False, single_output: bool = True) -> Optional[int | float]:
@@ -170,7 +168,6 @@ class RoleHandlers:
 
         return possible
 
-    @unbox_context_args
     async def info(self, ctx: commands.Context | discord.Interaction, role: discord.Role | str) -> None:
         """
         Handler for the info commands.
@@ -203,7 +200,6 @@ class RoleHandlers:
         else:
             await ctx.response.send_message(embed=embed)
 
-    @unbox_context_args
     async def list_server_roles(self, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the list commands.
@@ -228,7 +224,6 @@ class RoleHandlers:
         await embed.set_page(1)
         await embed.send()
 
-    @unbox_context_args
     async def members(self, ctx: commands.Context | discord.Interaction, role: discord.Role | str) -> None:
         """
         Handler for the members commands.
@@ -285,7 +280,6 @@ class RoleHandlers:
 
         await self.checked_role_change(ctx, role, member, "remove")
 
-    @unbox_context_args
     async def swap(self, ctx: commands.Context | discord.Interaction, swap_from: discord.Role | str,
                    swap_to: discord.Role | str) -> None:
         """
@@ -349,7 +343,6 @@ class RoleHandlers:
                                                                 + (
                                                                     "" if already_got_dest_role == 0 else f" ({already_got_dest_role} already had {swap_to.mention})"))
 
-    @unbox_context_args
     async def removeall(self, ctx: commands.Context | discord.Interaction, role: discord.Role | str) -> None:
         """
         Handler for the removeall commands.
@@ -395,7 +388,6 @@ class RoleHandlers:
 
         await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Nothing to do!", desc="Nobody has this role!")
 
-    @unbox_context_args
     async def addall(self, ctx: commands.Context | discord.Interaction, ref_role: discord.Role | str,
                      add_role: discord.Role | str) -> None:
         """

--- a/cogs/guild/guild_features/starboard/starboard_handlers.py
+++ b/cogs/guild/guild_features/starboard/starboard_handlers.py
@@ -243,14 +243,9 @@ class StarboardHandlers:
         Handler for the view commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type is self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         starboards = await self._get_starboards(ctx.guild.id)
         embed = self.bot.EmbedPages(

--- a/cogs/guild/guild_features/starboard/starboard_handlers.py
+++ b/cogs/guild/guild_features/starboard/starboard_handlers.py
@@ -5,8 +5,9 @@ from typing import Optional
 import discord
 from discord.ext import commands
 from emoji import get_emoji_regexp
+from libs.misc.decorators import unbox_context
 
-from libs.misc.utils import get_user_avatar_url, get_guild_icon_url
+from libs.misc.utils import ContextTypes, get_user_avatar_url, get_guild_icon_url
 from .starboard_container import StarboardContainer
 
 
@@ -238,14 +239,11 @@ class StarboardHandlers:
                     elif entry or entry.bot_message is None:
                         await entry.update_bot_message(msg)
 
-    async def view(self, ctx: commands.Context | discord.Interaction) -> None:
+    @unbox_context
+    async def view(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the view commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         starboards = await self._get_starboards(ctx.guild.id)
         embed = self.bot.EmbedPages(

--- a/cogs/guild/guild_features/starboard/starboard_handlers.py
+++ b/cogs/guild/guild_features/starboard/starboard_handlers.py
@@ -5,17 +5,16 @@ from typing import Optional
 import discord
 from discord.ext import commands
 from emoji import get_emoji_regexp
-from libs.misc.decorators import unbox_context_args
 
-from libs.misc.utils import ContextTypes, get_user_avatar_url, get_guild_icon_url
+from libs.misc.handler import CommandHandler
+from libs.misc.utils import get_user_avatar_url, get_guild_icon_url
 from .starboard_container import StarboardContainer
 
 
-class StarboardHandlers:
+class StarboardHandlers(CommandHandler):
     def __init__(self, bot, cog) -> None:
-        self.bot = bot
+        super().__init__(self, bot)
         self.cog = cog
-        self.ContextTypes = self.bot.ContextTypes
 
     # --- Starboard embed ---
     async def make_starboard_embed(self, message: discord.Message, stars: int, emoji: discord.Emoji,
@@ -239,7 +238,6 @@ class StarboardHandlers:
                     elif entry or entry.bot_message is None:
                         await entry.update_bot_message(msg)
 
-    @unbox_context_args
     async def view(self, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the view commands.

--- a/cogs/guild/guild_features/starboard/starboard_handlers.py
+++ b/cogs/guild/guild_features/starboard/starboard_handlers.py
@@ -5,7 +5,7 @@ from typing import Optional
 import discord
 from discord.ext import commands
 from emoji import get_emoji_regexp
-from libs.misc.decorators import unbox_context
+from libs.misc.decorators import unbox_context_args
 
 from libs.misc.utils import ContextTypes, get_user_avatar_url, get_guild_icon_url
 from .starboard_container import StarboardContainer
@@ -239,12 +239,13 @@ class StarboardHandlers:
                     elif entry or entry.bot_message is None:
                         await entry.update_bot_message(msg)
 
-    @unbox_context
-    async def view(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None:
+    @unbox_context_args
+    async def view(self, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the view commands.
         """
 
+        (ctx_type, author) = self.command_args
         starboards = await self._get_starboards(ctx.guild.id)
         embed = self.bot.EmbedPages(
             self.bot.PageTypes.STARBOARD_LIST,

--- a/cogs/guild/member_features/qotd/qotd.py
+++ b/cogs/guild/member_features/qotd/qotd.py
@@ -28,12 +28,9 @@ async def qotd_predicate(ctx: commands.Context | discord.Interaction):
     else:
         return
 
-    ctx_type = bot.get_context_type(ctx)
-
-    if ctx_type == bot.ContextTypes.Context:
-        author = ctx.author
-    else:
-        author = ctx.user
+    ctx_type, author = bot.unbox_context(ctx)
+    if not author:
+        return
 
     qotd_role_id = await bot.get_config_key(ctx, "qotd_role")
     staff_role_id = await bot.get_config_key(ctx, "staff_role")

--- a/cogs/guild/member_features/qotd/qotd.py
+++ b/cogs/guild/member_features/qotd/qotd.py
@@ -6,7 +6,7 @@ from discord import app_commands
 from discord.app_commands import AppCommandError
 from discord.ext import commands
 
-from libs.misc.utils import DefaultEmbedResponses
+from libs.misc.utils import DefaultEmbedResponses, unbox_context
 from . import qotd_handlers
 
 
@@ -28,7 +28,7 @@ async def qotd_predicate(ctx: commands.Context | discord.Interaction):
     else:
         return
 
-    ctx_type, author = bot.unbox_context(ctx)
+    ctx_type, author = unbox_context(ctx)
     if not author:
         return
 

--- a/cogs/guild/member_features/qotd/qotd_handlers.py
+++ b/cogs/guild/member_features/qotd/qotd_handlers.py
@@ -7,7 +7,8 @@ from discord import Embed, Colour
 from discord.ext import commands
 
 from adambot import AdamBot
-from libs.misc.utils import get_user_avatar_url, get_guild_icon_url
+from libs.misc.decorators import unbox_context
+from libs.misc.utils import ContextTypes, get_user_avatar_url, get_guild_icon_url
 
 
 class QOTDHandlers:
@@ -15,14 +16,11 @@ class QOTDHandlers:
         self.bot = bot
         self.ContextTypes = self.bot.ContextTypes
 
-    async def submit(self, ctx: commands.Context | discord.Interaction, qotd: str) -> None:
+    @unbox_context
+    async def submit(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, qotd: str) -> None:
         """
         Handler for the submit commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         if len(qotd) > 255:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Could not submit question!",
@@ -71,14 +69,11 @@ class QOTDHandlers:
                     embed.set_footer(text=self.bot.correct_time().strftime(self.bot.ts_format))
                     await log.send(embed=embed)
 
-    async def qotd_list(self, ctx: commands.Context | discord.Interaction, page_num: int = 1) -> None:
+    @unbox_context
+    async def qotd_list(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, page_num: int = 1) -> None:
         """
         Handler for the list commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         async with self.bot.pool.acquire() as connection:
             qotds = await connection.fetch("SELECT * FROM qotd WHERE guild_id = $1 ORDER BY id", ctx.guild.id)
@@ -104,14 +99,11 @@ class QOTDHandlers:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Nothing here!",
                                                              desc="This server does not currently have any QOTDs!")
 
-    async def delete(self, ctx: commands.Context | discord.Interaction, question_ids: str) -> None:
+    @unbox_context
+    async def delete(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, question_ids: str) -> None:
         """
         Handler for the delete commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         question_ids = question_ids.split(" ")
 
@@ -139,14 +131,11 @@ class QOTDHandlers:
 
         await self.bot.DefaultEmbedResponses.information_embed(self.bot, ctx, "Finished deleting QOTDs", desc=info)
 
-    async def pick(self, ctx: commands.Context | discord.Interaction, question_id: str | int) -> None:
+    @unbox_context
+    async def pick(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, question_id: str | int) -> None:
         """
         Handler for the pick commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         qotd_channel_id = await self.bot.get_config_key(ctx, "qotd_channel")
         if qotd_channel_id is None:

--- a/cogs/guild/member_features/qotd/qotd_handlers.py
+++ b/cogs/guild/member_features/qotd/qotd_handlers.py
@@ -20,14 +20,9 @@ class QOTDHandlers:
         Handler for the submit commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         if len(qotd) > 255:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Could not submit question!",
@@ -38,11 +33,7 @@ class QOTDHandlers:
             await ctx.send(f"```{ctx.prefix}qotd submit <question>```")
             return
 
-        if ctx_type == self.ContextTypes.Context:
-            member = ctx.author.id
-        else:
-            member = ctx.user.id
-
+        member = author.id
         is_staff = await self.bot.is_staff(ctx)
 
         today = datetime.datetime.utcnow().date()
@@ -85,14 +76,9 @@ class QOTDHandlers:
         Handler for the list commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         async with self.bot.pool.acquire() as connection:
             qotds = await connection.fetch("SELECT * FROM qotd WHERE guild_id = $1 ORDER BY id", ctx.guild.id)
@@ -123,14 +109,9 @@ class QOTDHandlers:
         Handler for the delete commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         question_ids = question_ids.split(" ")
 
@@ -163,14 +144,9 @@ class QOTDHandlers:
         Handler for the pick commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         qotd_channel_id = await self.bot.get_config_key(ctx, "qotd_channel")
         if qotd_channel_id is None:

--- a/cogs/guild/member_features/qotd/qotd_handlers.py
+++ b/cogs/guild/member_features/qotd/qotd_handlers.py
@@ -7,16 +7,14 @@ from discord import Embed, Colour
 from discord.ext import commands
 
 from adambot import AdamBot
-from libs.misc.decorators import unbox_context_args
-from libs.misc.utils import ContextTypes, get_user_avatar_url, get_guild_icon_url
+from libs.misc.handler import CommandHandler
+from libs.misc.utils import get_user_avatar_url, get_guild_icon_url
 
 
-class QOTDHandlers:
+class QOTDHandlers(CommandHandler):
     def __init__(self, bot: AdamBot) -> None:
-        self.bot = bot
-        self.ContextTypes = self.bot.ContextTypes
+        super().__init__(self, bot)
 
-    @unbox_context_args
     async def submit(self, ctx: commands.Context | discord.Interaction, qotd: str) -> None:
         """
         Handler for the submit commands.
@@ -70,7 +68,6 @@ class QOTDHandlers:
                     embed.set_footer(text=self.bot.correct_time().strftime(self.bot.ts_format))
                     await log.send(embed=embed)
 
-    @unbox_context_args
     async def qotd_list(self, ctx: commands.Context | discord.Interaction, page_num: int = 1) -> None:
         """
         Handler for the list commands.
@@ -101,7 +98,6 @@ class QOTDHandlers:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Nothing here!",
                                                              desc="This server does not currently have any QOTDs!")
 
-    @unbox_context_args
     async def delete(self, ctx: commands.Context | discord.Interaction, question_ids: str) -> None:
         """
         Handler for the delete commands.
@@ -134,7 +130,6 @@ class QOTDHandlers:
 
         await self.bot.DefaultEmbedResponses.information_embed(self.bot, ctx, "Finished deleting QOTDs", desc=info)
 
-    @unbox_context_args
     async def pick(self, ctx: commands.Context | discord.Interaction, question_id: str | int) -> None:
         """
         Handler for the pick commands.

--- a/cogs/guild/member_features/qotd/qotd_handlers.py
+++ b/cogs/guild/member_features/qotd/qotd_handlers.py
@@ -7,7 +7,7 @@ from discord import Embed, Colour
 from discord.ext import commands
 
 from adambot import AdamBot
-from libs.misc.decorators import unbox_context
+from libs.misc.decorators import unbox_context_args
 from libs.misc.utils import ContextTypes, get_user_avatar_url, get_guild_icon_url
 
 
@@ -16,12 +16,13 @@ class QOTDHandlers:
         self.bot = bot
         self.ContextTypes = self.bot.ContextTypes
 
-    @unbox_context
-    async def submit(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, qotd: str) -> None:
+    @unbox_context_args
+    async def submit(self, ctx: commands.Context | discord.Interaction, qotd: str) -> None:
         """
         Handler for the submit commands.
         """
 
+        (ctx_type, author) = self.command_args
         if len(qotd) > 255:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Could not submit question!",
                                                              desc="Question over **255** characters, please **shorten** before trying the command again.")
@@ -69,12 +70,13 @@ class QOTDHandlers:
                     embed.set_footer(text=self.bot.correct_time().strftime(self.bot.ts_format))
                     await log.send(embed=embed)
 
-    @unbox_context
-    async def qotd_list(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, page_num: int = 1) -> None:
+    @unbox_context_args
+    async def qotd_list(self, ctx: commands.Context | discord.Interaction, page_num: int = 1) -> None:
         """
         Handler for the list commands.
         """
 
+        (ctx_type, author) = self.command_args
         async with self.bot.pool.acquire() as connection:
             qotds = await connection.fetch("SELECT * FROM qotd WHERE guild_id = $1 ORDER BY id", ctx.guild.id)
 
@@ -99,12 +101,13 @@ class QOTDHandlers:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Nothing here!",
                                                              desc="This server does not currently have any QOTDs!")
 
-    @unbox_context
-    async def delete(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, question_ids: str) -> None:
+    @unbox_context_args
+    async def delete(self, ctx: commands.Context | discord.Interaction, question_ids: str) -> None:
         """
         Handler for the delete commands.
         """
 
+        (ctx_type, author) = self.command_args
         question_ids = question_ids.split(" ")
 
         info = ""
@@ -131,12 +134,13 @@ class QOTDHandlers:
 
         await self.bot.DefaultEmbedResponses.information_embed(self.bot, ctx, "Finished deleting QOTDs", desc=info)
 
-    @unbox_context
-    async def pick(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, question_id: str | int) -> None:
+    @unbox_context_args
+    async def pick(self, ctx: commands.Context | discord.Interaction, question_id: str | int) -> None:
         """
         Handler for the pick commands.
         """
 
+        (ctx_type, author) = self.command_args
         qotd_channel_id = await self.bot.get_config_key(ctx, "qotd_channel")
         if qotd_channel_id is None:
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "Could not pick QOTD!",

--- a/cogs/guild/member_features/reputation/reputation_handlers.py
+++ b/cogs/guild/member_features/reputation/reputation_handlers.py
@@ -4,7 +4,8 @@ from discord import Embed, Colour
 from discord.ext import commands
 
 from adambot import AdamBot
-from libs.misc.utils import get_user_avatar_url, get_guild_icon_url
+from libs.misc.decorators import unbox_context
+from libs.misc.utils import ContextTypes, get_user_avatar_url, get_guild_icon_url
 
 
 class ReputationHandlers:
@@ -12,14 +13,11 @@ class ReputationHandlers:
         self.bot = bot
         self.ContextTypes = self.bot.ContextTypes
 
-    async def get_leaderboard(self, ctx: commands.Context | discord.Interaction) -> None:
+    @unbox_context
+    async def get_leaderboard(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None:
         """
         Constructs and sends an embed containing the reputation leaderboard for the context guild.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         async with self.bot.pool.acquire() as connection:
             leaderboard = await connection.fetch(
@@ -92,15 +90,12 @@ class ReputationHandlers:
                     new_reps = reps
                 return new_reps
 
-    async def award(self, ctx: commands.Context | discord.Interaction, args: discord.Member | discord.User | str = "",
+    @unbox_context
+    async def award(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, args: discord.Member | discord.User | str = "",
                     member: discord.Member = "") -> None:
         """
         Handler for the award commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         if args:
             if type(args) == discord.Member:
@@ -186,14 +181,11 @@ class ReputationHandlers:
 
         await self.get_leaderboard(ctx)
 
-    async def all(self, ctx: commands.Context | discord.Interaction) -> None:
+    @unbox_context
+    async def all(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the all commands. (No this isn't a typo ;) )
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         async with self.bot.pool.acquire() as connection:
             await connection.execute("DELETE from rep WHERE guild_id = $1", ctx.guild.id)
@@ -211,15 +203,12 @@ class ReputationHandlers:
         embed.set_footer(text=self.bot.correct_time().strftime(self.bot.ts_format))
         await channel.send(embed=embed)
 
-    async def set(self, ctx: commands.Context | discord.Interaction, user: discord.Member | discord.User,
+    @unbox_context
+    async def set(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, user: discord.Member | discord.User,
                   rep: str | int) -> None:
         """
         Handler for the set commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         if type(rep) is str and not rep.isdigit():
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "The reputation points must be a number!")
@@ -241,14 +230,11 @@ class ReputationHandlers:
         embed.set_footer(text=self.bot.correct_time().strftime(self.bot.ts_format))
         await channel.send(embed=embed)
 
-    async def hardset(self, ctx: commands.Context | discord.Interaction, user_id: str, rep: int | str) -> None:
+    @unbox_context
+    async def hardset(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, user_id: str, rep: int | str) -> None:
         """
         Handler for the hardset commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         if not user_id.isdigit():
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "The user's ID must be a valid ID!")
@@ -282,15 +268,12 @@ class ReputationHandlers:
         embed.set_footer(text=self.bot.correct_time().strftime(self.bot.ts_format))
         await channel.send(embed=embed)
 
-    async def check(self, ctx: commands.Context | discord.Interaction, args: str = "",
+    @unbox_context
+    async def check(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, args: str = "",
                     member: discord.Member | discord.User = "") -> None:
         """
         Handler for the check commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         if not args:
             user = author if not member else member

--- a/cogs/guild/member_features/reputation/reputation_handlers.py
+++ b/cogs/guild/member_features/reputation/reputation_handlers.py
@@ -4,16 +4,14 @@ from discord import Embed, Colour
 from discord.ext import commands
 
 from adambot import AdamBot
-from libs.misc.decorators import unbox_context_args
-from libs.misc.utils import ContextTypes, get_user_avatar_url, get_guild_icon_url
+from libs.misc.handler import CommandHandler
+from libs.misc.utils import get_user_avatar_url, get_guild_icon_url
 
 
-class ReputationHandlers:
+class ReputationHandlers(CommandHandler):
     def __init__(self, bot: AdamBot) -> None:
-        self.bot = bot
-        self.ContextTypes = self.bot.ContextTypes
+        super().__init__(self, bot)
 
-    @unbox_context_args
     async def get_leaderboard(self, ctx: commands.Context | discord.Interaction) -> None:
         """
         Constructs and sends an embed containing the reputation leaderboard for the context guild.
@@ -91,7 +89,6 @@ class ReputationHandlers:
                     new_reps = reps
                 return new_reps
 
-    @unbox_context_args
     async def award(self, ctx: commands.Context | discord.Interaction, args: discord.Member | discord.User | str = "",
                     member: discord.Member = "") -> None:
         """
@@ -183,7 +180,6 @@ class ReputationHandlers:
 
         await self.get_leaderboard(ctx)
 
-    @unbox_context_args
     async def all(self, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the all commands. (No this isn't a typo ;) )
@@ -206,7 +202,6 @@ class ReputationHandlers:
         embed.set_footer(text=self.bot.correct_time().strftime(self.bot.ts_format))
         await channel.send(embed=embed)
 
-    @unbox_context_args
     async def set(self, ctx: commands.Context | discord.Interaction, user: discord.Member | discord.User,
                   rep: str | int) -> None:
         """
@@ -234,7 +229,6 @@ class ReputationHandlers:
         embed.set_footer(text=self.bot.correct_time().strftime(self.bot.ts_format))
         await channel.send(embed=embed)
 
-    @unbox_context_args
     async def hardset(self, ctx: commands.Context | discord.Interaction, user_id: str, rep: int | str) -> None:
         """
         Handler for the hardset commands.
@@ -273,7 +267,6 @@ class ReputationHandlers:
         embed.set_footer(text=self.bot.correct_time().strftime(self.bot.ts_format))
         await channel.send(embed=embed)
 
-    @unbox_context_args
     async def check(self, ctx: commands.Context | discord.Interaction, args: str = "",
                     member: discord.Member | discord.User = "") -> None:
         """

--- a/cogs/guild/member_features/reputation/reputation_handlers.py
+++ b/cogs/guild/member_features/reputation/reputation_handlers.py
@@ -17,15 +17,9 @@ class ReputationHandlers:
         Constructs and sends an embed containing the reputation leaderboard for the context guild.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         async with self.bot.pool.acquire() as connection:
             leaderboard = await connection.fetch(
@@ -104,15 +98,9 @@ class ReputationHandlers:
         Handler for the award commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         if args:
             if type(args) == discord.Member:
@@ -203,14 +191,9 @@ class ReputationHandlers:
         Handler for the all commands. (No this isn't a typo ;) )
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         async with self.bot.pool.acquire() as connection:
             await connection.execute("DELETE from rep WHERE guild_id = $1", ctx.guild.id)
@@ -234,14 +217,9 @@ class ReputationHandlers:
         Handler for the set commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         if type(rep) is str and not rep.isdigit():
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "The reputation points must be a number!")
@@ -268,14 +246,9 @@ class ReputationHandlers:
         Handler for the hardset commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         if not user_id.isdigit():
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "The user's ID must be a valid ID!")
@@ -315,14 +288,9 @@ class ReputationHandlers:
         Handler for the check commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         if not args:
             user = author if not member else member

--- a/cogs/guild/member_features/reputation/reputation_handlers.py
+++ b/cogs/guild/member_features/reputation/reputation_handlers.py
@@ -4,7 +4,7 @@ from discord import Embed, Colour
 from discord.ext import commands
 
 from adambot import AdamBot
-from libs.misc.decorators import unbox_context
+from libs.misc.decorators import unbox_context_args
 from libs.misc.utils import ContextTypes, get_user_avatar_url, get_guild_icon_url
 
 
@@ -13,12 +13,13 @@ class ReputationHandlers:
         self.bot = bot
         self.ContextTypes = self.bot.ContextTypes
 
-    @unbox_context
-    async def get_leaderboard(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None:
+    @unbox_context_args
+    async def get_leaderboard(self, ctx: commands.Context | discord.Interaction) -> None:
         """
         Constructs and sends an embed containing the reputation leaderboard for the context guild.
         """
 
+        (ctx_type, author) = self.command_args
         async with self.bot.pool.acquire() as connection:
             leaderboard = await connection.fetch(
                 "SELECT member_id, reps FROM rep WHERE guild_id = $1 ORDER BY reps DESC", ctx.guild.id)
@@ -90,13 +91,14 @@ class ReputationHandlers:
                     new_reps = reps
                 return new_reps
 
-    @unbox_context
-    async def award(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, args: discord.Member | discord.User | str = "",
+    @unbox_context_args
+    async def award(self, ctx: commands.Context | discord.Interaction, args: discord.Member | discord.User | str = "",
                     member: discord.Member = "") -> None:
         """
         Handler for the award commands.
         """
 
+        (ctx_type, author) = self.command_args
         if args:
             if type(args) == discord.Member:
                 user = args
@@ -181,12 +183,13 @@ class ReputationHandlers:
 
         await self.get_leaderboard(ctx)
 
-    @unbox_context
-    async def all(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None:
+    @unbox_context_args
+    async def all(self, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the all commands. (No this isn't a typo ;) )
         """
 
+        (ctx_type, author) = self.command_args
         async with self.bot.pool.acquire() as connection:
             await connection.execute("DELETE from rep WHERE guild_id = $1", ctx.guild.id)
 
@@ -203,13 +206,14 @@ class ReputationHandlers:
         embed.set_footer(text=self.bot.correct_time().strftime(self.bot.ts_format))
         await channel.send(embed=embed)
 
-    @unbox_context
-    async def set(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, user: discord.Member | discord.User,
+    @unbox_context_args
+    async def set(self, ctx: commands.Context | discord.Interaction, user: discord.Member | discord.User,
                   rep: str | int) -> None:
         """
         Handler for the set commands.
         """
 
+        (ctx_type, author) = self.command_args
         if type(rep) is str and not rep.isdigit():
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "The reputation points must be a number!")
             return
@@ -230,12 +234,13 @@ class ReputationHandlers:
         embed.set_footer(text=self.bot.correct_time().strftime(self.bot.ts_format))
         await channel.send(embed=embed)
 
-    @unbox_context
-    async def hardset(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, user_id: str, rep: int | str) -> None:
+    @unbox_context_args
+    async def hardset(self, ctx: commands.Context | discord.Interaction, user_id: str, rep: int | str) -> None:
         """
         Handler for the hardset commands.
         """
 
+        (ctx_type, author) = self.command_args
         if not user_id.isdigit():
             await self.bot.DefaultEmbedResponses.error_embed(self.bot, ctx, "The user's ID must be a valid ID!")
             return
@@ -268,13 +273,14 @@ class ReputationHandlers:
         embed.set_footer(text=self.bot.correct_time().strftime(self.bot.ts_format))
         await channel.send(embed=embed)
 
-    @unbox_context
-    async def check(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, args: str = "",
+    @unbox_context_args
+    async def check(self, ctx: commands.Context | discord.Interaction, args: str = "",
                     member: discord.Member | discord.User = "") -> None:
         """
         Handler for the check commands.
         """
 
+        (ctx_type, author) = self.command_args
         if not args:
             user = author if not member else member
         else:

--- a/cogs/guild/member_features/support/support_handlers.py
+++ b/cogs/guild/member_features/support/support_handlers.py
@@ -16,14 +16,9 @@ class SupportHandlers:
         Handler for the accept commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         try:
             ticket = int(ticket)
@@ -75,8 +70,8 @@ class SupportHandlers:
         Handler for the connections commands.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
 
         current = []

--- a/cogs/guild/member_features/support/support_handlers.py
+++ b/cogs/guild/member_features/support/support_handlers.py
@@ -2,7 +2,7 @@ import discord
 from discord import Embed, Colour
 from discord.ext import commands
 
-from libs.misc.decorators import unbox_context
+from libs.misc.decorators import unbox_context_args
 from libs.misc.utils import ContextTypes
 
 from .support_connection import MessageOrigin
@@ -14,12 +14,13 @@ class SupportHandlers:
         self.cog = cog
         self.ContextTypes = self.bot.ContextTypes
 
-    @unbox_context
-    async def accept(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, ticket: str | int) -> None:
+    @unbox_context_args
+    async def accept(self, ctx: commands.Context | discord.Interaction, ticket: str | int) -> None:
         """
         Handler for the accept commands.
         """
 
+        (ctx_type, author) = self.command_args
         try:
             ticket = int(ticket)
         except ValueError:
@@ -65,8 +66,8 @@ class SupportHandlers:
                 return
             await channel.send(embed=embed)
 
-    @unbox_context
-    async def connections(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None:
+    @unbox_context_args
+    async def connections(self, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the connections commands.
         """
@@ -91,6 +92,7 @@ class SupportHandlers:
         y = newline.join(waiting)
         string = f"__**Current connections**__{newline}{x}{newline}__**Waiting connections**__{newline}{y}"
 
+        (ctx_type, author) = self.command_args
         if ctx_type == self.ContextTypes.Context:
             await ctx.send(string)
         else:

--- a/cogs/guild/member_features/support/support_handlers.py
+++ b/cogs/guild/member_features/support/support_handlers.py
@@ -2,6 +2,9 @@ import discord
 from discord import Embed, Colour
 from discord.ext import commands
 
+from libs.misc.decorators import unbox_context
+from libs.misc.utils import ContextTypes
+
 from .support_connection import MessageOrigin
 
 
@@ -11,14 +14,11 @@ class SupportHandlers:
         self.cog = cog
         self.ContextTypes = self.bot.ContextTypes
 
-    async def accept(self, ctx: commands.Context | discord.Interaction, ticket: str | int) -> None:
+    @unbox_context
+    async def accept(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, ticket: str | int) -> None:
         """
         Handler for the accept commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         try:
             ticket = int(ticket)
@@ -65,14 +65,11 @@ class SupportHandlers:
                 return
             await channel.send(embed=embed)
 
-    async def connections(self, ctx: commands.Context | discord.Interaction) -> None:
+    @unbox_context
+    async def connections(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the connections commands.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         current = []
         waiting = []

--- a/cogs/guild/member_features/support/support_handlers.py
+++ b/cogs/guild/member_features/support/support_handlers.py
@@ -2,19 +2,16 @@ import discord
 from discord import Embed, Colour
 from discord.ext import commands
 
-from libs.misc.decorators import unbox_context_args
-from libs.misc.utils import ContextTypes
+from libs.misc.handler import CommandHandler
 
 from .support_connection import MessageOrigin
 
 
-class SupportHandlers:
+class SupportHandlers(CommandHandler):
     def __init__(self, bot, cog) -> None:
-        self.bot = bot
+        super().__init__(self, bot)
         self.cog = cog
-        self.ContextTypes = self.bot.ContextTypes
 
-    @unbox_context_args
     async def accept(self, ctx: commands.Context | discord.Interaction, ticket: str | int) -> None:
         """
         Handler for the accept commands.
@@ -66,7 +63,6 @@ class SupportHandlers:
                 return
             await channel.send(embed=embed)
 
-    @unbox_context_args
     async def connections(self, ctx: commands.Context | discord.Interaction) -> None:
         """
         Handler for the connections commands.

--- a/cogs/member/member.py
+++ b/cogs/member/member.py
@@ -129,7 +129,7 @@ class Member(commands.Cog):
         """
 
         await ctx.message.delete()
-        await ctx.send(await self.Handlers.cringe())
+        await ctx.send(await self.Handlers.cringe(ctx))
 
     @app_commands.command(
         name="cringe",
@@ -140,7 +140,7 @@ class Member(commands.Cog):
         Slash command equivalent of the classic command "cringe"
         """
 
-        await interaction.response.send_message(await self.Handlers.cringe())
+        await interaction.response.send_message(await self.Handlers.cringe(interaction))
 
     @commands.command()
     @commands.guild_only()

--- a/cogs/member/member_handlers.py
+++ b/cogs/member/member_handlers.py
@@ -5,24 +5,22 @@ import discord
 from discord import Embed, Colour, Status, app_commands
 from discord.ext import commands
 
-from libs.misc.utils import get_user_avatar_url, get_guild_icon_url
+from libs.misc.decorators import unbox_context
+from libs.misc.utils import get_user_avatar_url, get_guild_icon_url, ContextTypes
 
 
 class MemberHandlers:
     def __init__(self, bot) -> None:
         self.bot = bot
-        self.ContextTypes = self.bot.ContextTypes
+        self.ContextTypes = bot.ContextTypes
 
-    async def quote(self, ctx: commands.Context | discord.Interaction, messageid: int | str,
+    @unbox_context
+    async def quote(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, messageid: int | str,
                     channel: int | discord.TextChannel | discord.Thread | app_commands.AppCommandThread) -> None:
         """
         Handler method for the classic and slash quote commands.
         Fetches and displays a specified message from its ID and a channel ID if it exists.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         if type(channel) is int:
             channelid = channel
@@ -47,7 +45,7 @@ class MemberHandlers:
 
         embed = Embed(title="Quote link",
                       url=f"https://discordapp.com/channels/{channelid}/{messageid}",
-                      color=user.color,
+                      color=author.color,
                       timestamp=msg.created_at)
 
         if image:
@@ -113,17 +111,14 @@ class MemberHandlers:
 
         return "https://cdn.discordapp.com/attachments/593965137266868234/829480599542562866/cringe.mp4"
 
-    async def spamping(self, ctx: commands.Context | discord.Interaction, amount: str | int,
+    @unbox_context
+    async def spamping(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, amount: str | int,
                        user: discord.Member | discord.Role, message) -> None:
         """
         Handler for the spamping commands.
 
         Pings a given user role with a given message a specified number of times.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         try:
             amount = int(amount)
@@ -145,18 +140,15 @@ class MemberHandlers:
                 await ctx.channel.send(msg)
         else:
             await self.bot.DefaultEmbedResponses.invalid_perms(self.bot, ctx)
-
-    async def ghostping(self, ctx: commands.Context | discord.Interaction, user: discord.Member | discord.Role,
+    
+    @unbox_context
+    async def ghostping(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, user: discord.Member | discord.Role,
                         amount: str | int) -> None:
         """
         Handler for the ghostping commands.
 
         Ghost-pings a given user role with a given message a specified number of times.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         try:
             amount = int(amount)
@@ -363,16 +355,13 @@ class MemberHandlers:
 
         return data
 
-    async def remind(self, ctx: commands.Context | discord.Interaction, time: int, reason: str = "") -> None:
+    @unbox_context
+    async def remind(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, time: int, reason: str = "") -> None:
         """
         Handler for setting up a reminder.
 
         Submits a reminder task with a given reason and time.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         str_tp = self.bot.time_str(time)  # runs it through a convertor because hodor's OCD cannot take seeing 100000s
         str_reason = "*Reminder:* " + (reason if reason else "(Not specified)")
@@ -414,16 +403,13 @@ class MemberHandlers:
         else:
             return f"**ACCOUNT AVATAR (TOP):**\n{avatar_urls[0]}\n**SERVER AVATAR (BOTTOM):**\n{avatar_urls[1]}"
 
-    async def gcses(self, ctx: commands.Context | discord.Interaction, command: str = "gcses") -> None:
+    @unbox_context
+    async def gcses(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, command: str = "gcses") -> None:
         """
         Handler for the gcses commands.
 
         Constructs and displays the countdown embed.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         embed = Embed(title="Information on UK exams", color=Colour.from_rgb(148, 0, 211))
         now = self.bot.correct_time()
@@ -447,16 +433,14 @@ class MemberHandlers:
         else:
             await ctx.response.send_message(embed=embed)
 
-    async def resultsday(self, ctx: commands.Context | discord.Interaction, hour: int | str = 10, which="GCSE") -> None:
+
+    @unbox_context
+    async def resultsday(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, hour: int | str = 10, which="GCSE") -> None:
         """
         Handler for the resultsday commands.
 
         Constructs and displays the countdown embed.
         """
-
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
 
         try:
             hour = int(hour)

--- a/cogs/member/member_handlers.py
+++ b/cogs/member/member_handlers.py
@@ -5,17 +5,13 @@ import discord
 from discord import Embed, Colour, Status, app_commands
 from discord.ext import commands
 
-from libs.misc.decorators import unbox_context_args
-from libs.misc.utils import get_user_avatar_url, get_guild_icon_url, ContextTypes
+from libs.misc.utils import get_user_avatar_url, get_guild_icon_url
+from libs.misc.handler import CommandHandler
 
-
-class MemberHandlers:
+class MemberHandlers(CommandHandler):
     def __init__(self, bot) -> None:
-        self.bot = bot
-        self.ContextTypes = bot.ContextTypes
-        self.command_args = None # Used to store output from `ubnox_context_args`
+        super().__init__(self, bot)
 
-    @unbox_context_args
     async def quote(self, ctx: commands.Context | discord.Interaction, messageid: int | str,
                     channel: int | discord.TextChannel | discord.Thread | app_commands.AppCommandThread) -> None:
         """
@@ -111,8 +107,7 @@ class MemberHandlers:
 
         return "https://cdn.discordapp.com/attachments/593965137266868234/829480599542562866/cringe.mp4"
 
-    @unbox_context_args
-    async def spamping(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, amount: str | int,
+    async def spamping(self, ctx: commands.Context | discord.Interaction, amount: str | int,
                        user: discord.Member | discord.Role, message) -> None:
         """
         Handler for the spamping commands.
@@ -143,7 +138,6 @@ class MemberHandlers:
         else:
             await self.bot.DefaultEmbedResponses.invalid_perms(self.bot, ctx)
     
-    @unbox_context_args
     async def ghostping(self, ctx: commands.Context | discord.Interaction, user: discord.Member | discord.Role,
                         amount: str | int) -> None:
         """
@@ -359,7 +353,6 @@ class MemberHandlers:
 
         return data
 
-    @unbox_context_args
     async def remind(self, ctx: commands.Context | discord.Interaction, time: int, reason: str = "") -> None:
         """
         Handler for setting up a reminder.
@@ -408,7 +401,6 @@ class MemberHandlers:
         else:
             return f"**ACCOUNT AVATAR (TOP):**\n{avatar_urls[0]}\n**SERVER AVATAR (BOTTOM):**\n{avatar_urls[1]}"
 
-    @unbox_context_args
     async def gcses(self, ctx: commands.Context | discord.Interaction, command: str = "gcses") -> None:
         """
         Handler for the gcses commands.
@@ -441,7 +433,6 @@ class MemberHandlers:
             await ctx.response.send_message(embed=embed)
 
 
-    @unbox_context_args
     async def resultsday(self, ctx: commands.Context | discord.Interaction, hour: int | str = 10, which="GCSE") -> None:
         """
         Handler for the resultsday commands.

--- a/cogs/member/member_handlers.py
+++ b/cogs/member/member_handlers.py
@@ -5,7 +5,7 @@ import discord
 from discord import Embed, Colour, Status, app_commands
 from discord.ext import commands
 
-from libs.misc.decorators import unbox_context
+from libs.misc.decorators import unbox_context_args
 from libs.misc.utils import get_user_avatar_url, get_guild_icon_url, ContextTypes
 
 
@@ -13,14 +13,16 @@ class MemberHandlers:
     def __init__(self, bot) -> None:
         self.bot = bot
         self.ContextTypes = bot.ContextTypes
+        self.command_args = None # Used to store output from `ubnox_context_args`
 
-    @unbox_context
-    async def quote(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, messageid: int | str,
+    @unbox_context_args
+    async def quote(self, ctx: commands.Context | discord.Interaction, messageid: int | str,
                     channel: int | discord.TextChannel | discord.Thread | app_commands.AppCommandThread) -> None:
         """
         Handler method for the classic and slash quote commands.
         Fetches and displays a specified message from its ID and a channel ID if it exists.
         """
+        (ctx_type, author) = self.command_args # Unpack command args
 
         if type(channel) is int:
             channelid = channel
@@ -75,8 +77,7 @@ class MemberHandlers:
 
         return f"•**Global** bruh moments: **{global_bruhs}**\n•**{guild.name}** bruh moments: **{guild_bruhs}**"
 
-    @staticmethod
-    async def cool(text: str) -> str:
+    async def cool(self, text: str) -> str:
         """
         A handler for the "cool" commands.
 
@@ -101,8 +102,7 @@ class MemberHandlers:
                 new += letter
         return new
 
-    @staticmethod
-    async def cringe() -> str:
+    async def cringe(self, ctx) -> str:
         """
         Handler for the "cringe" commands.
 
@@ -111,7 +111,7 @@ class MemberHandlers:
 
         return "https://cdn.discordapp.com/attachments/593965137266868234/829480599542562866/cringe.mp4"
 
-    @unbox_context
+    @unbox_context_args
     async def spamping(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, amount: str | int,
                        user: discord.Member | discord.Role, message) -> None:
         """
@@ -119,6 +119,8 @@ class MemberHandlers:
 
         Pings a given user role with a given message a specified number of times.
         """
+
+        (ctx_type, author) = self.command_args # Unpack command args
 
         try:
             amount = int(amount)
@@ -141,14 +143,16 @@ class MemberHandlers:
         else:
             await self.bot.DefaultEmbedResponses.invalid_perms(self.bot, ctx)
     
-    @unbox_context
-    async def ghostping(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, user: discord.Member | discord.Role,
+    @unbox_context_args
+    async def ghostping(self, ctx: commands.Context | discord.Interaction, user: discord.Member | discord.Role,
                         amount: str | int) -> None:
         """
         Handler for the ghostping commands.
 
         Ghost-pings a given user role with a given message a specified number of times.
         """
+
+        (ctx_type, author) = self.command_args # Unpack command args
 
         try:
             amount = int(amount)
@@ -355,13 +359,15 @@ class MemberHandlers:
 
         return data
 
-    @unbox_context
-    async def remind(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, time: int, reason: str = "") -> None:
+    @unbox_context_args
+    async def remind(self, ctx: commands.Context | discord.Interaction, time: int, reason: str = "") -> None:
         """
         Handler for setting up a reminder.
 
         Submits a reminder task with a given reason and time.
         """
+        
+        (ctx_type, author) = self.command_args # Unpack command args
 
         str_tp = self.bot.time_str(time)  # runs it through a convertor because hodor's OCD cannot take seeing 100000s
         str_reason = "*Reminder:* " + (reason if reason else "(Not specified)")
@@ -388,8 +394,7 @@ class MemberHandlers:
 
         return f"Adam-Bot code can be found here: {self.bot.CODE_URL}"
 
-    @staticmethod
-    async def avatar(member: discord.Member | discord.User) -> str:
+    async def avatar(self, member: discord.Member | discord.User) -> str:
         """
         Handler for the avatar commands.
 
@@ -403,13 +408,15 @@ class MemberHandlers:
         else:
             return f"**ACCOUNT AVATAR (TOP):**\n{avatar_urls[0]}\n**SERVER AVATAR (BOTTOM):**\n{avatar_urls[1]}"
 
-    @unbox_context
-    async def gcses(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, command: str = "gcses") -> None:
+    @unbox_context_args
+    async def gcses(self, ctx: commands.Context | discord.Interaction, command: str = "gcses") -> None:
         """
         Handler for the gcses commands.
 
         Constructs and displays the countdown embed.
         """
+
+        (ctx_type, author) = self.command_args # Unpack command args
 
         embed = Embed(title="Information on UK exams", color=Colour.from_rgb(148, 0, 211))
         now = self.bot.correct_time()
@@ -434,13 +441,15 @@ class MemberHandlers:
             await ctx.response.send_message(embed=embed)
 
 
-    @unbox_context
-    async def resultsday(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, hour: int | str = 10, which="GCSE") -> None:
+    @unbox_context_args
+    async def resultsday(self, ctx: commands.Context | discord.Interaction, hour: int | str = 10, which="GCSE") -> None:
         """
         Handler for the resultsday commands.
 
         Constructs and displays the countdown embed.
         """
+
+        (ctx_type, author) = self.command_args # Unpack command args
 
         try:
             hour = int(hour)

--- a/cogs/member/member_handlers.py
+++ b/cogs/member/member_handlers.py
@@ -20,8 +20,8 @@ class MemberHandlers:
         Fetches and displays a specified message from its ID and a channel ID if it exists.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type is self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
 
         if type(channel) is int:
@@ -36,7 +36,6 @@ class MemberHandlers:
                                                              desc="Could not find a message with the given ID!")
             return
 
-        user = msg.author
         image = None
         repl = re.compile(r"/(\[.+?)(\(.+?\))/")
         edited = f" (edited at {msg.edited_at.isoformat(' ', 'seconds')})" if msg.edited_at else ""
@@ -53,8 +52,8 @@ class MemberHandlers:
 
         if image:
             embed.set_image(url=image)
-        embed.set_footer(text=f"Sent by {user.name}#{user.discriminator}",
-                         icon_url=get_user_avatar_url(user, mode=1)[0])
+        embed.set_footer(text=f"Sent by {author.name}#{author.discriminator}",
+                         icon_url=get_user_avatar_url(author, mode=1)[0])
         embed.description = f"❝ {content} ❞" + edited
 
         if ctx_type == self.ContextTypes.Context:
@@ -122,14 +121,9 @@ class MemberHandlers:
         Pings a given user role with a given message a specified number of times.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type is self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         try:
             amount = int(amount)
@@ -160,14 +154,9 @@ class MemberHandlers:
         Ghost-pings a given user role with a given message a specified number of times.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type is self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         try:
             amount = int(amount)
@@ -381,14 +370,9 @@ class MemberHandlers:
         Submits a reminder task with a given reason and time.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type is self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         str_tp = self.bot.time_str(time)  # runs it through a convertor because hodor's OCD cannot take seeing 100000s
         str_reason = "*Reminder:* " + (reason if reason else "(Not specified)")
@@ -437,14 +421,9 @@ class MemberHandlers:
         Constructs and displays the countdown embed.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type is self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         embed = Embed(title="Information on UK exams", color=Colour.from_rgb(148, 0, 211))
         now = self.bot.correct_time()
@@ -475,14 +454,9 @@ class MemberHandlers:
         Constructs and displays the countdown embed.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type is self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         try:
             hour = int(hour)

--- a/cogs/member/spotify_handlers.py
+++ b/cogs/member/spotify_handlers.py
@@ -3,16 +3,14 @@ from discord import Embed, Colour
 from discord.ext import commands
 
 from adambot import AdamBot
-from libs.misc.decorators import unbox_context_args
-from libs.misc.utils import get_user_avatar_url, ContextTypes
+from libs.misc.handler import CommandHandler
+from libs.misc.utils import get_user_avatar_url
 
 
-class SpotifyHandlers:
+class SpotifyHandlers(CommandHandler):
     def __init__(self, bot: AdamBot) -> None:
-        self.bot = bot
-        self.ContextTypes = self.bot.ContextTypes
+        super().__init__(self, bot)
 
-    @unbox_context_args
     async def spotify(self, ctx: commands.Context | discord.Interaction,
                       user: discord.Member | discord.User | str = "") -> None:
         """

--- a/cogs/member/spotify_handlers.py
+++ b/cogs/member/spotify_handlers.py
@@ -3,7 +3,7 @@ from discord import Embed, Colour
 from discord.ext import commands
 
 from adambot import AdamBot
-from libs.misc.decorators import unbox_context
+from libs.misc.decorators import unbox_context_args
 from libs.misc.utils import get_user_avatar_url, ContextTypes
 
 
@@ -12,9 +12,8 @@ class SpotifyHandlers:
         self.bot = bot
         self.ContextTypes = self.bot.ContextTypes
 
-    @unbox_context
-    async def spotify(self, ctx_type: ContextTypes, author: discord.User | discord.Member, 
-                      ctx: commands.Context | discord.Interaction,
+    @unbox_context_args
+    async def spotify(self, ctx: commands.Context | discord.Interaction,
                       user: discord.Member | discord.User | str = "") -> None:
         """
         Handler for the spotify commands.
@@ -22,6 +21,7 @@ class SpotifyHandlers:
         Constructs and send the spotifyinfo embeds.
         """
 
+        (ctx_type, author) = self.command_args
         if ctx_type != self.ContextTypes.Context:
             author = ctx.guild.get_member(ctx.user.id)
 

--- a/cogs/member/spotify_handlers.py
+++ b/cogs/member/spotify_handlers.py
@@ -3,7 +3,8 @@ from discord import Embed, Colour
 from discord.ext import commands
 
 from adambot import AdamBot
-from libs.misc.utils import get_user_avatar_url
+from libs.misc.decorators import unbox_context
+from libs.misc.utils import get_user_avatar_url, ContextTypes
 
 
 class SpotifyHandlers:
@@ -11,7 +12,9 @@ class SpotifyHandlers:
         self.bot = bot
         self.ContextTypes = self.bot.ContextTypes
 
-    async def spotify(self, ctx: commands.Context | discord.Interaction,
+    @unbox_context
+    async def spotify(self, ctx_type: ContextTypes, author: discord.User | discord.Member, 
+                      ctx: commands.Context | discord.Interaction,
                       user: discord.Member | discord.User | str = "") -> None:
         """
         Handler for the spotify commands.
@@ -19,9 +22,6 @@ class SpotifyHandlers:
         Constructs and send the spotifyinfo embeds.
         """
 
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
         if ctx_type != self.ContextTypes.Context:
             author = ctx.guild.get_member(ctx.user.id)
 

--- a/cogs/member/spotify_handlers.py
+++ b/cogs/member/spotify_handlers.py
@@ -19,13 +19,10 @@ class SpotifyHandlers:
         Constructs and send the spotifyinfo embeds.
         """
 
-        ctx_type = self.bot.get_context_type(ctx)
-        if ctx_type == self.ContextTypes.Unknown:
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == self.ContextTypes.Context:
-            author = ctx.author
-        else:
+        if ctx_type != self.ContextTypes.Context:
             author = ctx.guild.get_member(ctx.user.id)
 
         if not user or (type(user) is str and len(user) == 0):

--- a/core/config/config_handlers.py
+++ b/core/config/config_handlers.py
@@ -7,7 +7,7 @@ import discord
 from discord.ext import commands
 
 from adambot import AdamBot
-from libs.misc.utils import get_guild_icon_url, get_user_avatar_url, ContextTypes, get_context_type
+from libs.misc.utils import get_guild_icon_url, get_user_avatar_url, ContextTypes, unbox_context
 
 
 class Validation(Enum):
@@ -33,14 +33,9 @@ class ConfigHandlers:
         Method that checks if a user is staff in their guild or not. `ctx` may be `discord.Message` or `discord.ext.commands.Context`
         """
 
-        ctx_type = get_context_type(ctx)
-        if ctx_type is ContextTypes.Unknown:
+        ctx_type, author = unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         try:
             staff_role_id = await self.get_config_key(ctx, "staff_role")
@@ -159,8 +154,8 @@ class ConfigHandlers:
             await connection.execute(sql, *data.values())
 
     async def what_prefixes(self, ctx: commands.Context | discord.Interaction) -> None:
-        ctx_type = get_context_type(ctx)
-        if ctx_type == ContextTypes.Unknown:
+        ctx_type, author = unbox_context(ctx)
+        if not author:
             return
 
         msg = await self.bot.get_used_prefixes(ctx)
@@ -178,14 +173,11 @@ class ConfigHandlers:
          3. Pass the dict into EmbedPages for formatting
         """
 
-        ctx_type = get_context_type(ctx)
-        if ctx_type is ContextTypes.Unknown:
+        ctx_type, author = unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.guild.get_member(ctx.user.id)  # users do not have guild permissions, only members
+        if ctx_type == ContextTypes.Interaction:
+            author = ctx.guild.get_member(ctx.user.id) # users do not have guild permissions, only members
 
         if not (author.guild_permissions.administrator or await self.is_staff(ctx)):
             await self.bot.DefaultEmbedResponses.invalid_perms(self.bot, ctx)
@@ -231,14 +223,9 @@ class ConfigHandlers:
         await embed.send()
 
     async def set(self, ctx: commands.Context | discord.Interaction, key: str = "", value: str = "") -> None:
-        ctx_type = get_context_type(ctx)
-        if ctx_type is ContextTypes.Unknown:
+        ctx_type, author = unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         if not (author.guild_permissions.administrator or await self.is_staff(ctx)):
             await self.bot.DefaultEmbedResponses.invalid_perms(self.bot, ctx)
@@ -327,15 +314,9 @@ class ConfigHandlers:
                                                                f"It has been changed to '{value}'")
 
     async def remove(self, ctx: commands.Context | discord.Interaction, key: str) -> None:
-
-        ctx_type = get_context_type(ctx)
-        if ctx_type is ContextTypes.Unknown:
+        ctx_type, author = unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         if not (author.guild_permissions.administrator or await self.is_staff(ctx)):
             await self.bot.DefaultEmbedResponses.invalid_perms(self.bot, ctx)
@@ -352,15 +333,9 @@ class ConfigHandlers:
                                                            "It has been changed to ***N/A***")
 
     async def current(self, ctx: commands.Context | discord.Interaction, key: str) -> None:
-
-        ctx_type = get_context_type(ctx)
-        if ctx_type is ContextTypes.Unknown:
+        ctx_type, author = unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == ContextTypes.Context:
-            author = ctx.author
-        else:
-            author = ctx.user
 
         if not (author.guild_permissions.administrator or await self.is_staff(ctx)):
             await self.bot.DefaultEmbedResponses.invalid_perms(self.bot, ctx)
@@ -392,10 +367,10 @@ class ConfigHandlers:
             prefix = await self.get_config_key(ctx, "prefix")
             await self.bot.DefaultEmbedResponses.information_embed(self.bot, ctx, "Current value of prefix", prefix)
         else:
-            ctx_type = get_context_type(ctx)
-            if ctx_type == ContextTypes.Context:
-                author = ctx.author
-            else:
+            ctx_type, author = unbox_context(ctx)
+            if not author:
+                return
+            if ctx_type == ContextTypes.Interaction:
                 author = ctx.guild.get_member(ctx.user.id)
 
             if not (author.guild_permissions.administrator or await self.is_staff(ctx)):

--- a/core/config/config_handlers.py
+++ b/core/config/config_handlers.py
@@ -7,7 +7,7 @@ import discord
 from discord.ext import commands
 
 from adambot import AdamBot
-from libs.misc.decorators import unbox_context_args
+from libs.misc.handler import CommandHandler
 from libs.misc.utils import get_guild_icon_url, get_user_avatar_url, ContextTypes
 
 
@@ -23,13 +23,12 @@ def get_validator(value) -> int:
     return getattr(Validation, value)
 
 
-class ConfigHandlers:
+class ConfigHandlers(CommandHandler):
     def __init__(self, bot: AdamBot, cog: commands.Cog) -> None:
-        self.bot = bot
+        super().__init__(self, bot)
         self.cog = cog
         self.Validation = Validation
 
-    @unbox_context_args
     async def is_staff(self, ctx: commands.Context | discord.Interaction) -> None | bool:
         """
         Method that checks if a user is staff in their guild or not. `ctx` may be `discord.Message` or `discord.ext.commands.Context`
@@ -152,7 +151,6 @@ class ConfigHandlers:
         async with self.bot.pool.acquire() as connection:
             await connection.execute(sql, *data.values())
 
-    @unbox_context_args
     async def what_prefixes(self, ctx: commands.Context | discord.Interaction) -> None:
         (ctx_type, author) = self.command_args
         msg = await self.bot.get_used_prefixes(ctx)
@@ -161,7 +159,6 @@ class ConfigHandlers:
         else:
             await ctx.response.send_message(str(msg))
 
-    @unbox_context_args
     async def view(self, ctx: commands.Context | discord.Interaction) -> None:
         """
          To get the config options
@@ -217,7 +214,6 @@ class ConfigHandlers:
         await embed.set_page(1)  # Default first page
         await embed.send()
 
-    @unbox_context_args
     async def set(self, ctx: commands.Context | discord.Interaction, key: str = "", value: str = "") -> None:
         (ctx_type, author) = self.command_args
         if not (author.guild_permissions.administrator or await self.is_staff(ctx)):
@@ -306,7 +302,6 @@ class ConfigHandlers:
             await self.bot.DefaultEmbedResponses.success_embed(self.bot, ctx, f"{key} has been updated!",
                                                                f"It has been changed to '{value}'")
 
-    @unbox_context_args
     async def remove(self, ctx: commands.Context | discord.Interaction, key: str) -> None:
         (ctx_type, author) = self.command_args
         if not (author.guild_permissions.administrator or await self.is_staff(ctx)):
@@ -323,7 +318,6 @@ class ConfigHandlers:
         await self.bot.DefaultEmbedResponses.success_embed(self.bot, ctx, f"{key} has been updated!",
                                                            "It has been changed to ***N/A***")
 
-    @unbox_context_args
     async def current(self, ctx: commands.Context | discord.Interaction, key: str) -> None:
         (ctx_type, author) = self.command_args
         if not (author.guild_permissions.administrator or await self.is_staff(ctx)):
@@ -349,7 +343,6 @@ class ConfigHandlers:
                                                                    config_dict[key] if config_dict[
                                                                        key] else "***N/A***")
 
-    @unbox_context_args
     async def prefix(self, ctx: commands.Context | discord.Interaction, new_prefix: str = "") -> None:
         (ctx_type, author) = self.command_args
         await self.add_config(ctx.guild.id)

--- a/core/config/config_handlers.py
+++ b/core/config/config_handlers.py
@@ -7,7 +7,7 @@ import discord
 from discord.ext import commands
 
 from adambot import AdamBot
-from libs.misc.decorators import unbox_context
+from libs.misc.decorators import unbox_context_args
 from libs.misc.utils import get_guild_icon_url, get_user_avatar_url, ContextTypes
 
 
@@ -29,12 +29,13 @@ class ConfigHandlers:
         self.cog = cog
         self.Validation = Validation
 
-    @unbox_context
-    async def is_staff(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None | bool:
+    @unbox_context_args
+    async def is_staff(self, ctx: commands.Context | discord.Interaction) -> None | bool:
         """
         Method that checks if a user is staff in their guild or not. `ctx` may be `discord.Message` or `discord.ext.commands.Context`
         """
 
+        (ctx_type, author) = self.command_args
         try:
             staff_role_id = await self.get_config_key(ctx, "staff_role")
             return staff_role_id in [y.id for y in author.roles] or author.guild_permissions.administrator
@@ -151,17 +152,17 @@ class ConfigHandlers:
         async with self.bot.pool.acquire() as connection:
             await connection.execute(sql, *data.values())
 
-    @unbox_context
-    async def what_prefixes(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None:
+    @unbox_context_args
+    async def what_prefixes(self, ctx: commands.Context | discord.Interaction) -> None:
+        (ctx_type, author) = self.command_args
         msg = await self.bot.get_used_prefixes(ctx)
-
         if ctx_type == ContextTypes.Context:
             await ctx.send(str(msg))
         else:
             await ctx.response.send_message(str(msg))
 
-    @unbox_context
-    async def view(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction) -> None:
+    @unbox_context_args
+    async def view(self, ctx: commands.Context | discord.Interaction) -> None:
         """
          To get the config options
          1. Copy self.CONFIG into a new variable
@@ -169,6 +170,7 @@ class ConfigHandlers:
          3. Pass the dict into EmbedPages for formatting
         """
 
+        (ctx_type, author) = self.command_args
         if ctx_type == ContextTypes.Interaction:
             author = ctx.guild.get_member(ctx.user.id) # users do not have guild permissions, only members
 
@@ -215,8 +217,9 @@ class ConfigHandlers:
         await embed.set_page(1)  # Default first page
         await embed.send()
 
-    @unbox_context
-    async def set(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, key: str = "", value: str = "") -> None:
+    @unbox_context_args
+    async def set(self, ctx: commands.Context | discord.Interaction, key: str = "", value: str = "") -> None:
+        (ctx_type, author) = self.command_args
         if not (author.guild_permissions.administrator or await self.is_staff(ctx)):
             await self.bot.DefaultEmbedResponses.invalid_perms(self.bot, ctx)
             return
@@ -303,8 +306,9 @@ class ConfigHandlers:
             await self.bot.DefaultEmbedResponses.success_embed(self.bot, ctx, f"{key} has been updated!",
                                                                f"It has been changed to '{value}'")
 
-    @unbox_context
-    async def remove(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, key: str) -> None:
+    @unbox_context_args
+    async def remove(self, ctx: commands.Context | discord.Interaction, key: str) -> None:
+        (ctx_type, author) = self.command_args
         if not (author.guild_permissions.administrator or await self.is_staff(ctx)):
             await self.bot.DefaultEmbedResponses.invalid_perms(self.bot, ctx)
             return
@@ -319,8 +323,9 @@ class ConfigHandlers:
         await self.bot.DefaultEmbedResponses.success_embed(self.bot, ctx, f"{key} has been updated!",
                                                            "It has been changed to ***N/A***")
 
-    @unbox_context
-    async def current(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, key: str) -> None:
+    @unbox_context_args
+    async def current(self, ctx: commands.Context | discord.Interaction, key: str) -> None:
+        (ctx_type, author) = self.command_args
         if not (author.guild_permissions.administrator or await self.is_staff(ctx)):
             await self.bot.DefaultEmbedResponses.invalid_perms(self.bot, ctx)
             return
@@ -344,8 +349,9 @@ class ConfigHandlers:
                                                                    config_dict[key] if config_dict[
                                                                        key] else "***N/A***")
 
-    @unbox_context
-    async def prefix(self, ctx_type: ContextTypes, author: discord.User | discord.Member, ctx: commands.Context | discord.Interaction, new_prefix: str = "") -> None:
+    @unbox_context_args
+    async def prefix(self, ctx: commands.Context | discord.Interaction, new_prefix: str = "") -> None:
+        (ctx_type, author) = self.command_args
         await self.add_config(ctx.guild.id)
 
         if new_prefix is None:

--- a/libs/misc/decorators.py
+++ b/libs/misc/decorators.py
@@ -1,10 +1,11 @@
 from typing import Callable, Optional
+import inspect
 
 import discord
 from discord import app_commands
 from discord.ext import commands
 
-from .utils import DEVS
+from .utils import DEVS, unbox_context as unbox_context_function
 
 """
 The rationale behind these error classes is to basically abstract the error embed
@@ -128,3 +129,27 @@ def is_dev_slash() -> Callable:
         return await dev_predicate(interaction)
 
     return app_commands.check(predicate)
+
+def unbox_context(func) -> Callable:
+    """
+    Decorator that wraps a function to unbox the context into `ContextType`
+    and author. Must be used to wrap functions with a signature `self,
+    ContextType, discord.User | discord.Member, commands.Context |
+    discord.Interaction, ...` where `self` is the command handler (i.e., the
+    first four arguments to the function must be `self, ctx_type, author, ctx)
+    """
+    async def decorator(self, ctx: commands.Context | discord.Interaction, *args, **kwargs):
+        ctx_type, author = unbox_context_function(ctx)
+        if not author:
+            return
+        
+        await func(self, ctx_type, author, ctx, *args, **kwargs)
+
+    decorator.__name__ = func.__name__
+    sig = inspect.signature(func)
+    new_sig = list(sig.parameters.values())
+    new_sig.pop(1)
+    new_sig.pop(1) # Pop out the ctx_type and author
+    decorator.__signature__ = sig.replace(parameters=tuple(new_sig))
+    
+    return decorator

--- a/libs/misc/decorators.py
+++ b/libs/misc/decorators.py
@@ -45,12 +45,11 @@ def get_bot(ctx: commands.Context | discord.Interaction):
 async def staff_predicate(ctx: commands.Context | discord.Interaction) -> Optional[bool]:
     # Get prereqs
     bot = get_bot(ctx)
-    ctx_type = bot.get_context_type(ctx)
-    if ctx_type == bot.ContextType.Unknown:
+    ctx_type, author = bot.unbox_context(ctx)
+    if not author:
         return
 
     # Raise MissingStaff if author doesn't have staff
-    author = ctx.author if ctx_type == bot.ContextTypes.Context else ctx.user
     staff_role_id = await bot.get_config_key(ctx, "staff_role")
 
     if staff_role_id in [y.id for y in author.roles] or author.guild_permissions.administrator:
@@ -64,12 +63,11 @@ async def staff_predicate(ctx: commands.Context | discord.Interaction) -> Option
 async def dev_predicate(ctx: commands.Context | discord.Interaction) -> Optional[bool]:
     # Get prereqs
     bot = get_bot(ctx)
-    ctx_type = bot.get_context_type(ctx)
-    if ctx_type == bot.ContextType.Unknown:
+    ctx_type, author = bot.unbox_context(ctx)
+    if not author:
         return
 
     # Raise MissingDev if author doesn't have staff
-    author = ctx.author if ctx_type == bot.ContextTypes.Context else ctx.user
     if author.id in DEVS:
         return True
     elif ctx_type == bot.ContextTypes.Context:

--- a/libs/misc/embed_pages.py
+++ b/libs/misc/embed_pages.py
@@ -177,7 +177,10 @@ class EmbedPages(discord.ui.View):
         Sends the embed message. The interaction times out after 300 seconds (5 minutes).
         """
 
-        ctx_type = self.bot.get_context_type(self.ctx)
+        ctx_type, author = self.bot.unbox_context(ctx)
+        if not author:
+            return
+
         if ctx_type == self.bot.ContextTypes.Context or (ctx_type == self.bot.ContextTypes.Interaction and self.ctx.response.is_done()) or not self.ctx:
             await self.channel.send(embed=self.embed, view=self)
         else:

--- a/libs/misc/embed_pages.py
+++ b/libs/misc/embed_pages.py
@@ -177,11 +177,9 @@ class EmbedPages(discord.ui.View):
         Sends the embed message. The interaction times out after 300 seconds (5 minutes).
         """
 
-        ctx_type, author = self.bot.unbox_context(ctx)
-        if not author:
-            return
+        ctx_is_context = issubclass(self.ctx.__class__, commands.Context)
 
-        if ctx_type == self.bot.ContextTypes.Context or (ctx_type == self.bot.ContextTypes.Interaction and self.ctx.response.is_done()) or not self.ctx:
+        if ctx_is_context or (not ctx_is_context and self.ctx.response.is_done()) or not self.ctx:
             await self.channel.send(embed=self.embed, view=self)
         else:
             await self.ctx.response.send_message(embed=self.embed, view=self)

--- a/libs/misc/handler.py
+++ b/libs/misc/handler.py
@@ -1,0 +1,57 @@
+import inspect
+from functools import wraps
+
+from discord.ext.commands import Context
+from discord import Interaction
+
+from .utils import ContextTypes, unbox_context
+from adambot import AdamBot
+
+def unbox_context_wrapper(handler, func):
+    @wraps(func)
+    async def wrapper(ctx, *args, **kwargs):
+        if isinstance(ctx, Context) or isinstance(ctx, Interaction):
+            ctx_type, author = unbox_context(ctx)
+            if not author:
+                return
+            # Pass the correct arguments for the provided booleans
+            handler.command_args = ctx_type, author
+
+        wrapper.__name__ = func.__name__
+        wrapper.__signature__ = inspect.signature(func)
+
+        return await func(ctx, *args, **kwargs)
+    return wrapper
+
+class CommandHandler:
+    """
+    Base command handler class that is used to register command functionality
+    with. This class should be used as a superclass only and not instantiated
+    by itself. For a function of `CommandHandler` to have automatic contetxt
+    unboxing it must be awaitable and also have `"ctx"` as the first argument
+    (after self) with type `discord.Interaction` or `commands.Context` and
+    will output the ctx_type and author as a tuple in the handler's
+    `self.command_args`.
+    """
+    def __init__(self, sub_class, bot: AdamBot):
+        """
+        Sets `self.sub_class`, `self.bot` and `self.ContextTypes` as well
+        as decorating all functions with `unbox_context`.
+        """
+        self.sub_class = sub_class
+        self.bot = bot
+        self.ContextTypes = ContextTypes
+        self._decorate_functions()
+
+    def _decorate_functions(self):
+        for attr_name in type(self.sub_class).__dict__:
+            attr = getattr(self.sub_class, attr_name)
+            # Only assign decorator to the function if it has first arg with name "ctx"
+            should_decorate = False
+            try:
+                should_decorate = inspect.signature(attr).parameters["ctx"]
+            except:
+                pass
+
+            if should_decorate and inspect.iscoroutinefunction(attr):
+                setattr(self.sub_class, attr_name, unbox_context_wrapper(self.sub_class, getattr(self.sub_class, attr_name)))

--- a/libs/misc/utils.py
+++ b/libs/misc/utils.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from enum import Enum
 from io import BytesIO, StringIO
-from typing import Optional
+from typing import Optional, Tuple
 
 import discord
 from discord import Embed, Colour, File
@@ -49,8 +49,8 @@ async def send_image_file(ctx: commands.Context | discord.Interaction, fig,
     Send data to a channel with filename `filename`
     """
 
-    ctx_type = get_context_type(ctx)
-    if ctx_type is ContextTypes.Unknown:
+    ctx_type, author = unbox_context(ctx)
+    if not author:
         return
 
     buf = BytesIO()
@@ -70,8 +70,8 @@ async def send_text_file(ctx: commands.Context | discord.Interaction, text: str,
     Send a text data to a channel with filename `filename`
     """
 
-    ctx_type = get_context_type(ctx)
-    if ctx_type is ContextTypes.Unknown:
+    ctx_type, author = unbox_context(ctx)
+    if not author:
         return
 
     buf = StringIO()
@@ -357,14 +357,9 @@ class DefaultEmbedResponses:
         Internal procedure that is executed when a user has invalid perms
         """
 
-        ctx_type = get_context_type(ctx)
-        if ctx_type == ContextTypes.Unknown:
+        ctx_type, author = unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == ContextTypes.Context:
-            user = ctx.author
-        else:
-            user = ctx.user
 
         embed = Embed(title=f":x: You do not have permissions to do that!",
                       description="Only people with permissions (usually staff) can use this command!",
@@ -386,14 +381,9 @@ class DefaultEmbedResponses:
     async def error_embed(bot, ctx: commands.Context | discord.Interaction, title: str, desc: str = "",
                           thumbnail_url: str = "", bare: bool = False, respond_to_interaction=True) -> None | discord.Message:
 
-        ctx_type = get_context_type(ctx)
-        if ctx_type == ContextTypes.Unknown:
+        ctx_type, author = unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == ContextTypes.Context:
-            user = ctx.author
-        else:
-            user = ctx.user
 
         embed = Embed(title=f":x: {title}", description=desc, color=ERROR_RED)
         if not bare:
@@ -415,14 +405,9 @@ class DefaultEmbedResponses:
     async def success_embed(bot, ctx: commands.Context | discord.Interaction, title: str, desc: str = "",
                             thumbnail_url: str = "", bare: bool = False, respond_to_interaction=True) -> None | discord.Message:
 
-        ctx_type = get_context_type(ctx)
-        if ctx_type == ContextTypes.Unknown:
+        ctx_type, author = unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == ContextTypes.Context:
-            user = ctx.author
-        else:
-            user = ctx.user
 
         embed = Embed(title=f":white_check_mark: {title}", description=desc, color=SUCCESS_GREEN)
         if not bare:
@@ -442,14 +427,9 @@ class DefaultEmbedResponses:
     async def information_embed(bot, ctx: commands.Context | discord.Interaction, title: str, desc: str = "",
                                 thumbnail_url: str = "", bare: bool = False, respond_to_interaction=True) -> None | discord.Message:
 
-        ctx_type = get_context_type(ctx)
-        if ctx_type == ContextTypes.Unknown:
+        ctx_type, author = unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == ContextTypes.Context:
-            user = ctx.author
-        else:
-            user = ctx.user
 
         embed = Embed(title=f":information_source: {title}", description=desc, color=INFORMATION_BLUE)
         if not bare:
@@ -470,14 +450,9 @@ class DefaultEmbedResponses:
                              thumbnail_url: str = "", bare: bool = False,
                              respond_to_interaction=True) -> None | discord.Message:
 
-        ctx_type = get_context_type(ctx)
-        if ctx_type == ContextTypes.Unknown:
+        ctx_type, author = unbox_context(ctx)
+        if not author:
             return
-
-        if ctx_type == ContextTypes.Context:
-            user = ctx.author
-        else:
-            user = ctx.user
 
         embed = Embed(title=f":grey_question: {title}", description=desc, color=INFORMATION_BLUE)
         if not bare:
@@ -568,9 +543,13 @@ class ContextTypes(Enum):
     Interaction = 2
 
 
-def get_context_type(ctx: commands.Context | discord.Interaction) -> ContextTypes:
+def unbox_context(ctx: commands.Context | discord.Interaction) -> Tuple[ContextTypes, discord.User | bool]:
+    """
+    Method for returning the `ContextType` and the author of the context, the
+    author is `False` when the returned `ContextType` is unknown.
+    """
     if issubclass(ctx.__class__, commands.Context):
-        return ContextTypes.Context
+        return ContextTypes.Context, ctx.author
     elif issubclass(ctx.__class__, discord.Interaction):
-        return ContextTypes.Interaction
-    return ContextTypes.Unknown
+        return ContextTypes.Interaction, ctx.user
+    return ContextTypes.Unknown, False

--- a/libs/misc/utils.py
+++ b/libs/misc/utils.py
@@ -365,8 +365,8 @@ class DefaultEmbedResponses:
                       description="Only people with permissions (usually staff) can use this command!",
                       color=ERROR_RED)
         if not bare:
-            embed.set_footer(text=f"Requested by: {user.display_name} ({user})\n" + bot.correct_time().strftime(
-                bot.ts_format), icon_url=get_user_avatar_url(user, mode=1)[0])
+            embed.set_footer(text=f"Requested by: {author.display_name} ({author})\n" + bot.correct_time().strftime(
+                bot.ts_format), icon_url=get_user_avatar_url(author, mode=1)[0])
             if thumbnail_url:
                 embed.set_thumbnail(url=thumbnail_url)
 
@@ -388,8 +388,8 @@ class DefaultEmbedResponses:
         embed = Embed(title=f":x: {title}", description=desc, color=ERROR_RED)
         if not bare:
             if ctx_type == ContextTypes.Context:
-                embed.set_footer(text=f"Requested by: {user.display_name} ({user})\n" + bot.correct_time().strftime(
-                    bot.ts_format), icon_url=get_user_avatar_url(user, mode=1)[0])
+                embed.set_footer(text=f"Requested by: {author.display_name} ({author})\n" + bot.correct_time().strftime(
+                    bot.ts_format), icon_url=get_user_avatar_url(author, mode=1)[0])
 
             if thumbnail_url:
                 embed.set_thumbnail(url=thumbnail_url)
@@ -411,8 +411,8 @@ class DefaultEmbedResponses:
 
         embed = Embed(title=f":white_check_mark: {title}", description=desc, color=SUCCESS_GREEN)
         if not bare:
-            embed.set_footer(text=f"Requested by: {user.display_name} ({user})\n" + bot.correct_time().strftime(
-                bot.ts_format), icon_url=get_user_avatar_url(user, mode=1)[0])
+            embed.set_footer(text=f"Requested by: {author.display_name} ({author})\n" + bot.correct_time().strftime(
+                bot.ts_format), icon_url=get_user_avatar_url(author, mode=1)[0])
             if thumbnail_url:
                 embed.set_thumbnail(url=thumbnail_url)
 
@@ -433,8 +433,8 @@ class DefaultEmbedResponses:
 
         embed = Embed(title=f":information_source: {title}", description=desc, color=INFORMATION_BLUE)
         if not bare:
-            embed.set_footer(text=f"Requested by: {user.display_name} ({user})\n" + bot.correct_time().strftime(
-                bot.ts_format), icon_url=get_user_avatar_url(user, mode=1)[0])
+            embed.set_footer(text=f"Requested by: {author.display_name} ({author})\n" + bot.correct_time().strftime(
+                bot.ts_format), icon_url=get_user_avatar_url(author, mode=1)[0])
             if thumbnail_url:
                 embed.set_thumbnail(url=thumbnail_url)
 
@@ -456,8 +456,8 @@ class DefaultEmbedResponses:
 
         embed = Embed(title=f":grey_question: {title}", description=desc, color=INFORMATION_BLUE)
         if not bare:
-            embed.set_footer(text=f"Requested by: {user.display_name} ({user})\n" + bot.correct_time().strftime(
-                bot.ts_format), icon_url=get_user_avatar_url(user, mode=1)[0])
+            embed.set_footer(text=f"Requested by: {author.display_name} ({author})\n" + bot.correct_time().strftime(
+                bot.ts_format), icon_url=get_user_avatar_url(author, mode=1)[0])
             if thumbnail_url:
                 embed.set_thumbnail(url=thumbnail_url)
 


### PR DESCRIPTION
As the title suggests, refactoring duplicate codes in the handlers with the old `get_context_type` method. I may look at making a handler decorator that does the unboxing of context and passes it into the function it decorates to further reduce duplicate code.